### PR TITLE
MULE-10069: Artifact must export resource files instead of resource's…

### DIFF
--- a/src/main/resources/META-INF/mule-module.properties
+++ b/src/main/resources/META-INF/mule-module.properties
@@ -15,4 +15,4 @@ artifact.export.classPackages=org.mule.api,\
                               javax.xml.namespace,\
                               javax.net.ssl
 
-artifact.export.resourcePackages=/META-INF
+artifact.export.resources=/META-INF


### PR DESCRIPTION
… folder paths

_ Renaming artifact descriptor property artifact.export.resourcePackages to artifact.export.resources
