### PR TITLE
MULE-11654: Define privileged API

### DIFF
--- a/src/main/java/org/mule/runtime/api/message/Message.java
+++ b/src/main/java/org/mule/runtime/api/message/Message.java
@@ -24,11 +24,6 @@ import java.util.Iterator;
 public interface Message extends Serializable {
 
   /**
-   * Message with null payload and default values for every other attribute
-   */
-  Message NULL_MESSAGE = of(null);
-
-  /**
    * Provides a builder to create {@link Message} objects.
    *
    * @return a new {@link Builder}.


### PR DESCRIPTION
_ InternalMessage and some related classes will be part of the privileged API.
  To make that change, org.mule.runtime.api.message.AbstractMuleMessageBuilderFactory will have to use the container classloader to find the message factory, instead of using the current thread's context classloader.
  By doing that change, extensions maven plugin will fail to process extensions that have Message on their API.
  The problem is that the plugin depends on mule-api only, which is correct. But Message has a Message constant that has to be built. As the plugin has no dependency on mule-core, there is no message implementation that can be found.
  The fix at this moment is just to inline this constant, we will have to review if the approach used to separated mule API from the implementation is the right one.