### PR TITLE
MULE-10056: Maven module plugin is not properly detecting transitive …

### DIFF
--- a/src/main/resources/META-INF/mule-module.properties
+++ b/src/main/resources/META-INF/mule-module.properties
@@ -1,8 +1,6 @@
 module.name=mule-api
 
-artifact.export.classPackages=org.mule.api,\
-                              org.mule.runtime.api.app.config,\
-                              org.mule.runtime.api.app.declaration,\
+artifact.export.classPackages=org.mule.runtime.api.app.declaration,\
                               org.mule.runtime.api.app.declaration.fluent,\
                               org.mule.runtime.api.app.declaration.serialization,\
                               org.mule.runtime.api.artifact,\
@@ -13,16 +11,12 @@ artifact.export.classPackages=org.mule.api,\
                               org.mule.runtime.api.config.custom,\
                               org.mule.runtime.api.connection,\
                               org.mule.runtime.api.connection.serialization,\
-                              org.mule.runtime.api.deployment,\
                               org.mule.runtime.api.deployment.management,\
                               org.mule.runtime.api.deployment.persistence,\
                               org.mule.runtime.api.deployment.meta,\
                               org.mule.runtime.api.dsl,\
-                              org.mule.runtime.api.dsl.config,\
                               org.mule.runtime.api.el,\
                               org.mule.runtime.api.el.validation,\
-                              org.mule.runtime.api.execution,\
-                              org.mule.runtime.api.error,\
                               org.mule.runtime.api.exception,\
                               org.mule.runtime.api.i18n,\
                               org.mule.runtime.api.interception,\
@@ -45,7 +39,6 @@ artifact.export.classPackages=org.mule.api,\
                               org.mule.runtime.api.meta.model.declaration.fluent.util,\
                               org.mule.runtime.api.metadata,\
                               org.mule.runtime.api.metadata.descriptor,\
-                              org.mule.runtime.api.metadata.descriptor.builder,\
                               org.mule.runtime.api.metadata.resolving,\
                               org.mule.runtime.api.scheduler,\
                               org.mule.runtime.api.security,\


### PR DESCRIPTION
…exported dependencies

_ Removing un-existent packages
_ Adding missing exported packages
_ Adding optional packages
_ Removing non-required dependency from UUID artifact