### PR TITLE
MULE-12832: Avoid generating stacktraces for exceptions when verbose is

### DIFF
--- a/src/main/java/org/mule/runtime/api/exception/DefaultExceptionReader.java
+++ b/src/main/java/org/mule/runtime/api/exception/DefaultExceptionReader.java
@@ -16,16 +16,19 @@ import java.util.Map;
  */
 final class DefaultExceptionReader implements ExceptionReader {
 
-  private Map<?, ?> info = new HashMap<Object, Object>();
+  private Map<String, Object> info = new HashMap<>();
 
+  @Override
   public String getMessage(Throwable t) {
     return t.getMessage();
   }
 
+  @Override
   public Throwable getCause(Throwable t) {
     return t.getCause();
   }
 
+  @Override
   public Class<?> getExceptionType() {
     return Throwable.class;
   }
@@ -35,7 +38,8 @@ final class DefaultExceptionReader implements ExceptionReader {
    * 
    * @return a map of the non-stanard information stored on the exception
    */
-  public Map<?, ?> getInfo(Throwable t) {
+  @Override
+  public Map<String, Object> getInfo(Throwable t) {
     return info;
   }
 }

--- a/src/main/java/org/mule/runtime/api/exception/ExceptionHelper.java
+++ b/src/main/java/org/mule/runtime/api/exception/ExceptionHelper.java
@@ -6,6 +6,8 @@
  */
 package org.mule.runtime.api.exception;
 
+import static java.lang.System.lineSeparator;
+
 import org.mule.runtime.api.legacy.exception.ExceptionReader;
 
 import java.lang.reflect.InvocationTargetException;
@@ -15,8 +17,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * {@code ExceptionHelper} provides a number of helper functions that can be useful for dealing with Mule exceptions. This
- * class has 3 core functions -
+ * {@code ExceptionHelper} provides a number of helper functions that can be useful for dealing with Mule exceptions. This class
+ * has 3 core functions -
  * <p/>
  * 1. ErrorCode lookup. A corresponding Mule error code can be found using for a given Mule exception 2. Additional Error
  * information such as Java doc url for a given exception can be resolved using this class 3. Error code mappings can be looked up
@@ -31,8 +33,6 @@ public class ExceptionHelper {
   public static final String[] DEFAULT_STACKTRACE_FILTER =
       ("org.mule.runtime.core.processor.AbstractInterceptingMessageProcessor," + "org.mule.runtime.core.processor.chain")
           .split(",");
-
-  static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
   private static final int EXCEPTION_THRESHOLD = 3;
   private static boolean verbose = true;
@@ -140,8 +140,8 @@ public class ExceptionHelper {
     return cause instanceof MuleException ? null : cause;
   }
 
-  public static Map getExceptionInfo(Throwable t) {
-    Map info = new HashMap();
+  public static Map<String, Object> getExceptionInfo(Throwable t) {
+    Map<String, Object> info = new HashMap<>();
     Throwable cause = t;
     while (cause != null) {
       info.putAll(getExceptionReader(cause).getInfo(cause));
@@ -177,7 +177,7 @@ public class ExceptionHelper {
 
     ExceptionReader rootMuleReader = getExceptionReader(rootMule);
     buf.append(rootMuleReader.getMessage(rootMule)).append(" (").append(rootMule.getClass().getName()).append(")")
-        .append(LINE_SEPARATOR);
+        .append(lineSeparator());
 
     if (verbose) {
       int processedElements = 0;
@@ -194,12 +194,12 @@ public class ExceptionHelper {
 
         buf.append("  ").append(stackTraceElement.getClassName()).append(".").append(stackTraceElement.getMethodName())
             .append("(").append(stackTraceElement.getFileName()).append(":").append(stackTraceElement.getLineNumber()).append(")")
-            .append(LINE_SEPARATOR);
+            .append(lineSeparator());
       }
 
       if (root.getStackTrace().length - processedElements > 0) {
         buf.append("  (").append(root.getStackTrace().length - processedElements).append(" more...)")
-            .append(LINE_SEPARATOR);
+            .append(lineSeparator());
       }
     }
 

--- a/src/main/java/org/mule/runtime/api/exception/MuleExceptionReader.java
+++ b/src/main/java/org/mule/runtime/api/exception/MuleExceptionReader.java
@@ -6,9 +6,10 @@
  */
 package org.mule.runtime.api.exception;
 
+import static java.util.Collections.emptyMap;
+
 import org.mule.runtime.api.legacy.exception.ExceptionReader;
 
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -16,14 +17,17 @@ import java.util.Map;
  */
 final class MuleExceptionReader implements ExceptionReader {
 
+  @Override
   public String getMessage(Throwable t) {
     return t.getMessage();
   }
 
+  @Override
   public Throwable getCause(Throwable t) {
     return t.getCause();
   }
 
+  @Override
   public Class<?> getExceptionType() {
     return MuleException.class;
   }
@@ -33,8 +37,9 @@ final class MuleExceptionReader implements ExceptionReader {
    * 
    * @return a map of the non-stanard information stored on the exception
    */
-  public Map<?, ?> getInfo(Throwable t) {
-    return (t instanceof MuleException ? ((MuleException) t).getInfo() : Collections.EMPTY_MAP);
+  @Override
+  public Map<String, Object> getInfo(Throwable t) {
+    return (t instanceof MuleException ? ((MuleException) t).getInfo() : emptyMap());
   }
 
 }

--- a/src/main/java/org/mule/runtime/api/exception/MuleRuntimeException.java
+++ b/src/main/java/org/mule/runtime/api/exception/MuleRuntimeException.java
@@ -6,11 +6,13 @@
  */
 package org.mule.runtime.api.exception;
 
+import static org.mule.runtime.api.exception.MuleException.isVerboseExceptions;
+
 import org.mule.runtime.api.i18n.I18nMessage;
 
 /**
- * {@code MuleRuntimeException} Is the base runtime exception type for the Mule Server any other runtimes exceptions thrown
- * by Mule code will use or be based on this exception. Runtime exceptions in mule are only ever thrown where the method is not
+ * {@code MuleRuntimeException} Is the base runtime exception type for the Mule Server any other runtimes exceptions thrown by
+ * Mule code will use or be based on this exception. Runtime exceptions in mule are only ever thrown where the method is not
  * declared to throw an exception and the exception is serious.
  *
  * @since 1.0
@@ -26,7 +28,7 @@ public class MuleRuntimeException extends RuntimeException {
    * @param message the exception message
    */
   public MuleRuntimeException(I18nMessage message) {
-    super(message.getMessage());
+    this(message, null);
   }
 
   /**
@@ -34,13 +36,18 @@ public class MuleRuntimeException extends RuntimeException {
    * @param cause the exception that triggered this exception
    */
   public MuleRuntimeException(I18nMessage message, Throwable cause) {
-    super(message.getMessage(), cause);
+    this(message != null ? message.getMessage() : null, cause);
   }
 
   /**
    * @param cause the exception that triggered this exception
    */
   public MuleRuntimeException(Throwable cause) {
-    super(cause);
+    this(cause.toString(), cause);
   }
+
+  private MuleRuntimeException(String message, Throwable cause) {
+    super(message, cause, true, isVerboseExceptions());
+  }
+
 }

--- a/src/main/java/org/mule/runtime/api/exception/NamingExceptionReader.java
+++ b/src/main/java/org/mule/runtime/api/exception/NamingExceptionReader.java
@@ -6,9 +6,10 @@
  */
 package org.mule.runtime.api.exception;
 
+import static java.util.Collections.emptyMap;
+
 import org.mule.runtime.api.legacy.exception.ExceptionReader;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,14 +23,17 @@ class NamingExceptionReader implements ExceptionReader {
    */
   protected static final String MISSING_NAME_DISPLAY_VALUE = "<none>";
 
+  @Override
   public String getMessage(Throwable t) {
     return (t instanceof NamingException ? ((NamingException) t).toString(true) : "<unknown>");
   }
 
+  @Override
   public Throwable getCause(Throwable t) {
     return (t instanceof NamingException ? ((NamingException) t).getCause() : null);
   }
 
+  @Override
   public Class<?> getExceptionType() {
     return NamingException.class;
   }
@@ -40,7 +44,8 @@ class NamingExceptionReader implements ExceptionReader {
    * @param t the exception to extract the information from
    * @return a map of the non-stanard information stored on the exception
    */
-  public Map<?, ?> getInfo(Throwable t) {
+  @Override
+  public Map<String, Object> getInfo(Throwable t) {
     if (t instanceof NamingException) {
       NamingException e = (NamingException) t;
 
@@ -51,7 +56,7 @@ class NamingExceptionReader implements ExceptionReader {
       info.put("Resolved Name", resolvedName == null ? MISSING_NAME_DISPLAY_VALUE : resolvedName.toString());
       return info;
     } else {
-      return Collections.EMPTY_MAP;
+      return emptyMap();
     }
   }
 }

--- a/src/main/java/org/mule/runtime/api/legacy/exception/ExceptionReader.java
+++ b/src/main/java/org/mule/runtime/api/legacy/exception/ExceptionReader.java
@@ -26,6 +26,6 @@ public interface ExceptionReader {
    * @param t the exception to extract the information from
    * @return a map of the non-standard information stored on the exception
    */
-  Map<?, ?> getInfo(Throwable t);
+  Map<String, Object> getInfo(Throwable t);
 
 }


### PR DESCRIPTION
disabled
* Add generics to exception info
* Migrate uses of deprecated `SystemUtils.LINE_SEPARATOR`