### PR TITLE
MULE-12832: Avoid generating stacktraces for exceptions when verbose is

### DIFF
--- a/src/main/java/org/mule/runtime/api/exception/MuleException.java
+++ b/src/main/java/org/mule/runtime/api/exception/MuleException.java
@@ -52,6 +52,13 @@ public abstract class MuleException extends Exception {
   private I18nMessage i18nMessage;
 
   static {
+    refreshVerboseExceptions();
+  }
+
+  /**
+   * Reads the value of the {@code mule.verbose.exceptions} system property.
+   */
+  public static void refreshVerboseExceptions() {
     String p = System.getProperty(MULE_VERBOSE_EXCEPTIONS);
     if (p != null) {
       verboseExceptions = Boolean.parseBoolean(p);


### PR DESCRIPTION
disabled
* Fix tests