### PR TITLE
MULE-13545: Cleanup core API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <javax.inject.version>1</javax.inject.version>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
         <formatterGoal>validate</formatterGoal>
+        <guavaVersion>19.0</guavaVersion>
         <commonsLangVersion>3.6</commonsLangVersion>
         <license.maven.plugin.version>2.11</license.maven.plugin.version>
         <maven.surefire.plugin.version>2.20</maven.surefire.plugin.version>
@@ -157,6 +158,12 @@
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <version>${javax.inject.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+              <version>${guavaVersion}</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/src/main/java/org/mule/runtime/api/connectivity/ConnectivityTestingStrategy.java
+++ b/src/main/java/org/mule/runtime/api/connectivity/ConnectivityTestingStrategy.java
@@ -10,9 +10,9 @@ import org.mule.runtime.api.connection.ConnectionValidationResult;
 
 /**
  * An strategy for doing connectivity testing.
- *
+ * <p>
  * Instances of {@code ConnectivityTestingStrategy} will be discovered through SPI.
- *
+ * <p>
  * It's responsible to discover a mule component over the one connectivity testing can be done. Only one mule component for
  * connectivity testing must exists for the strategy to work.
  *

--- a/src/main/java/org/mule/runtime/api/connectivity/ConnectivityTestingStrategy.java
+++ b/src/main/java/org/mule/runtime/api/connectivity/ConnectivityTestingStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.connectivity;
+
+import org.mule.runtime.api.connection.ConnectionValidationResult;
+
+/**
+ * An strategy for doing connectivity testing.
+ *
+ * Instances of {@code ConnectivityTestingStrategy} will be discovered through SPI.
+ *
+ * It's responsible to discover a mule component over the one connectivity testing can be done. Only one mule component for
+ * connectivity testing must exists for the strategy to work.
+ *
+ * @since 1.0
+ */
+public interface ConnectivityTestingStrategy {
+
+  /**
+   * Does connectivity validation over the provided mule component.
+   *
+   * @return a {@code ConnectionValidationResult} describing the test connectivity result.
+   * @param connectivityTestingObject object over the one connectivity testing must be done
+   */
+  ConnectionValidationResult testConnectivity(Object connectivityTestingObject);
+
+  /**
+   * Determines if this {@code ConnectivityTestingStrategy} must be applied over the provided object.
+   *
+   * @param connectivityTestingObject object over the one connectivity testing must be done
+   * @return true if this strategy can do connectivity testing over the provided component, false otherwise.
+   */
+  boolean accepts(Object connectivityTestingObject);
+}

--- a/src/main/java/org/mule/runtime/api/connectivity/UnsupportedConnectivityTestingObjectException.java
+++ b/src/main/java/org/mule/runtime/api/connectivity/UnsupportedConnectivityTestingObjectException.java
@@ -6,7 +6,6 @@
  */
 package org.mule.runtime.api.connectivity;
 
-import org.mule.runtime.api.connectivity.ConnectivityTestingService;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.i18n.I18nMessage;
 

--- a/src/main/java/org/mule/runtime/api/exception/DefaultMuleException.java
+++ b/src/main/java/org/mule/runtime/api/exception/DefaultMuleException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.exception;
+
+import org.mule.runtime.api.i18n.I18nMessage;
+import org.mule.runtime.api.i18n.I18nMessageFactory;
+
+/**
+ * <code>MuleException</code> Is the base exception type for the Mule application any other exceptions thrown by Mule code will be
+ * based on this exception.
+ *
+ * @since 1.0
+ */
+public class DefaultMuleException extends MuleException {
+
+  /**
+   * Serial version
+   */
+  private static final long serialVersionUID = 2554735072826262515L;
+
+  public DefaultMuleException(String message) {
+    this(I18nMessageFactory.createStaticMessage(message));
+  }
+
+  /**
+   * @param message the exception message
+   */
+  public DefaultMuleException(I18nMessage message) {
+    super(message);
+  }
+
+  public DefaultMuleException(String message, Throwable cause) {
+    this(I18nMessageFactory.createStaticMessage(message), cause);
+  }
+
+  /**
+   * @param message the exception message
+   * @param cause the exception that cause this exception to be thrown
+   */
+  public DefaultMuleException(I18nMessage message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public DefaultMuleException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/org/mule/runtime/api/scheduler/SchedulerBusyException.java
+++ b/src/main/java/org/mule/runtime/api/scheduler/SchedulerBusyException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.scheduler;
+
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * Exception thrown by a {@link Scheduler} when all of its threads are busy and it cannot accept a new task for execution.
+ * 
+ * @since 1.0
+ */
+public class SchedulerBusyException extends RejectedExecutionException {
+
+  private static final long serialVersionUID = 9047649377760686741L;
+
+  /**
+   * Constructs a new exception with the specified message.
+   * 
+   * @param message the detail message
+   */
+  public SchedulerBusyException(String message) {
+    super(message);
+  }
+
+}
+

--- a/src/main/java/org/mule/runtime/api/scheduler/SchedulerConfig.java
+++ b/src/main/java/org/mule/runtime/api/scheduler/SchedulerConfig.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.scheduler;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * Provides a fluent way of customizing a {@link Scheduler} obtained through the {@link SchedulerService}.
+ *
+ * @since 1.0
+ */
+public class SchedulerConfig {
+
+  /**
+   * @return a default configuration, which can be further customized.
+   */
+  public static SchedulerConfig config() {
+    return new SchedulerConfig();
+  }
+
+  private final Integer maxConcurrentTasks;
+  private final String schedulerPrefix;
+  private final String schedulerName;
+  private final Optional<Boolean> waitAllowed;
+  private final Supplier<Long> shutdownTimeoutMillis;
+
+  private SchedulerConfig() {
+    this.maxConcurrentTasks = null;
+    this.schedulerPrefix = null;
+    this.schedulerName = null;
+    this.waitAllowed = empty();
+    this.shutdownTimeoutMillis = () -> null;
+  }
+
+  private SchedulerConfig(Integer maxConcurrentTasks, String schedulerPrefix, String schedulerName,
+                          Optional<Boolean> waitAllowed, Supplier<Long> shutdownTimeoutMillis) {
+    this.maxConcurrentTasks = maxConcurrentTasks;
+    this.schedulerPrefix = schedulerPrefix;
+    this.schedulerName = schedulerName;
+    this.waitAllowed = waitAllowed;
+    this.shutdownTimeoutMillis = shutdownTimeoutMillis;
+  }
+
+  /**
+   * Sets the max tasks that can be run at the same time for the target {@link Scheduler}.
+   * <p>
+   * This is useful to apply throttling on the target {@link Scheduler}. The way exceeding tasks will be handled is determined by
+   * the target {@link Scheduler}.
+   * 
+   * @param maxConcurrentTasks how many tasks can be running at the same time for the target {@link Scheduler}.
+   * @return the updated configuration.
+   */
+  public SchedulerConfig withMaxConcurrentTasks(int maxConcurrentTasks) {
+    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, waitAllowed, shutdownTimeoutMillis);
+  }
+
+  /**
+   * @return how many tasks can be running at the same time for the target {@link Scheduler}.
+   */
+  public Integer getMaxConcurrentTasks() {
+    return maxConcurrentTasks;
+  }
+
+  /**
+   * Sets the prefix to prepend to the name for the target {@link Scheduler}, which will override the default one.
+   * 
+   * @param schedulerPrefix the prefix for the name for the target {@link Scheduler}.
+   * @return the updated configuration.
+   */
+  public SchedulerConfig withPrefix(String schedulerPrefix) {
+    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, waitAllowed, shutdownTimeoutMillis);
+  }
+
+  /**
+   * Sets the name for the target {@link Scheduler}, which will override the default one.
+   * 
+   * @param schedulerName the name for the target {@link Scheduler}.
+   * @return the updated configuration.
+   */
+  public SchedulerConfig withName(String schedulerName) {
+    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, waitAllowed, shutdownTimeoutMillis);
+  }
+
+  /**
+   * @return the name for the target {@link Scheduler}.
+   */
+  public String getSchedulerName() {
+    return schedulerPrefix == null ? schedulerName : format("[%s].%s", schedulerPrefix, schedulerName);
+  }
+
+  /**
+   * @return {@code true} if {@link #withName(String)} was called with a non-null value, {@code false} otherwise.
+   */
+  public boolean hasName() {
+    return schedulerName != null;
+  }
+
+  /**
+   * Whether the threads of the target custom {@link Scheduler} may block to wait when dispatching to a busy {@link Scheduler}.
+   * <p>
+   * This is only applicable for <b>custom</b> {@link Scheduler}s. This behaviour cannot be changed for the runtime managed
+   * {@link Scheduler}.
+   * 
+   * @return the updated configuration
+   */
+  public SchedulerConfig withWaitAllowed(boolean waitAllowed) {
+    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, of(waitAllowed), shutdownTimeoutMillis);
+  }
+
+  /**
+   * @return whether the threads of the target custom {@link Scheduler} may block to wait when dispatching to a busy
+   *         {@link Scheduler}.
+   */
+  public Optional<Boolean> getWaitAllowed() {
+    return waitAllowed;
+  }
+
+  /**
+   * Sets the graceful shutdown timeout to use when stopping the target {@link Scheduler}.
+   * 
+   * @param shutdownTimeoutSupplier a supplier of the value of the timeout to use when gracefully stopping the target
+   *        {@link Scheduler}, expressed in the provided {@link TimeUnit}.
+   * @param shutdownTimeoutUnit the unit of the timeout to use when gracefully stopping the target {@link Scheduler}.
+   * @return the updated configuration
+   */
+  public SchedulerConfig withShutdownTimeout(Supplier<Long> shutdownTimeoutSupplier, TimeUnit shutdownTimeoutUnit) {
+    requireNonNull(shutdownTimeoutUnit);
+
+    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, waitAllowed, () -> {
+      long shutdownTimeout = shutdownTimeoutSupplier.get();
+      validateTimeoutValue(shutdownTimeout);
+      return shutdownTimeoutUnit.toMillis(shutdownTimeout);
+    });
+  }
+
+  /**
+   * Sets the graceful shutdown timeout to use when stopping the target {@link Scheduler}.
+   * 
+   * @param shutdownTimeout the value of the timeout to use when gracefully stopping the target {@link Scheduler}, expressed in
+   *        the provided {@link TimeUnit}.
+   * @param shutdownTimeoutUnit the unit of the timeout to use when gracefully stopping the target {@link Scheduler}.
+   * @return the updated configuration
+   */
+  public SchedulerConfig withShutdownTimeout(long shutdownTimeout, TimeUnit shutdownTimeoutUnit) {
+    requireNonNull(shutdownTimeoutUnit);
+    validateTimeoutValue(shutdownTimeout);
+    return withShutdownTimeout(() -> shutdownTimeout, shutdownTimeoutUnit);
+  }
+
+  private void validateTimeoutValue(long shutdownTimeout) {
+    if (shutdownTimeout < 0) {
+      throw new IllegalArgumentException(format("'shutdownTimeout' must be a possitive long. %d passed", shutdownTimeout));
+    }
+  }
+
+  /**
+   * @return a supplier of the timeout to use when gracefully stopping the target {@link Scheduler}, in millis.
+   */
+  public Supplier<Long> getShutdownTimeoutMillis() {
+    return shutdownTimeoutMillis;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SchedulerConfig that = (SchedulerConfig) o;
+
+    if (maxConcurrentTasks != null ? !maxConcurrentTasks.equals(that.maxConcurrentTasks) : that.maxConcurrentTasks != null) {
+      return false;
+    }
+    if (schedulerPrefix != null ? !schedulerPrefix.equals(that.schedulerPrefix) : that.schedulerPrefix != null) {
+      return false;
+    }
+    if (schedulerName != null ? !schedulerName.equals(that.schedulerName) : that.schedulerName != null) {
+      return false;
+    }
+    if (waitAllowed != null ? !waitAllowed.equals(that.waitAllowed) : that.waitAllowed != null) {
+      return false;
+    }
+    return shutdownTimeoutMillis != null ? shutdownTimeoutMillis.equals(that.shutdownTimeoutMillis)
+        : that.shutdownTimeoutMillis == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = maxConcurrentTasks != null ? maxConcurrentTasks.hashCode() : 0;
+    result = 31 * result + (schedulerPrefix != null ? schedulerPrefix.hashCode() : 0);
+    result = 31 * result + (schedulerName != null ? schedulerName.hashCode() : 0);
+    result = 31 * result + (waitAllowed != null ? waitAllowed.hashCode() : 0);
+    result = 31 * result + (shutdownTimeoutMillis != null ? shutdownTimeoutMillis.hashCode() : 0);
+    return result;
+  }
+}

--- a/src/main/java/org/mule/runtime/api/scheduler/SchedulerContainerPoolsConfig.java
+++ b/src/main/java/org/mule/runtime/api/scheduler/SchedulerContainerPoolsConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.scheduler;
+
+import static java.util.Optional.empty;
+
+import java.util.Optional;
+
+/**
+ * Singleton implementation whose {@link #getConfig()} method returns an empty value, to indicate that the container pools have to
+ * be used.
+ * 
+ * @since 1.0
+ */
+public class SchedulerContainerPoolsConfig implements SchedulerPoolsConfigFactory {
+
+  private static final SchedulerContainerPoolsConfig INSTANCE = new SchedulerContainerPoolsConfig();
+
+  public static SchedulerContainerPoolsConfig getInstance() {
+    return INSTANCE;
+  }
+
+  private SchedulerContainerPoolsConfig() {
+    // Nothing to do
+  }
+
+  @Override
+  public Optional<SchedulerPoolsConfig> getConfig() {
+    return empty();
+  }
+}

--- a/src/main/java/org/mule/runtime/api/scheduler/SchedulerPoolsConfig.java
+++ b/src/main/java/org/mule/runtime/api/scheduler/SchedulerPoolsConfig.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.scheduler;
+
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.concurrent.Executor;
+
+/**
+ * Parameters to use when building the {@link Executor}s for the scheduler service.
+ * 
+ * @since 1.0
+ */
+public interface SchedulerPoolsConfig {
+
+  /**
+   * @return the maximum time (in milliseconds) to wait until all tasks in all the runtime thread pools have completed execution
+   *         when stopping the scheduler service.
+   */
+  OptionalLong getGracefulShutdownTimeout();
+
+  /**
+   * @return the number of threads to keep in the {@code cpu_lite} pool, even if they are idle.
+   */
+  OptionalInt getCpuLightPoolSize();
+
+  /**
+   * @return the size of the queue to use for holding {@code cpu_lite} tasks before they are executed.
+   */
+  OptionalInt getCpuLightQueueSize();
+
+  /**
+   * @return the number of threads to keep in the {@code I/O} pool.
+   */
+  OptionalInt getIoCorePoolSize();
+
+  /**
+   * @return the maximum number of threads to allow in the {@code I/O} pool.
+   */
+  OptionalInt getIoMaxPoolSize();
+
+  /**
+   * @return the size of the queue to use for holding {@code I/O} tasks before they are executed.
+   */
+  OptionalInt getIoQueueSize();
+
+  /**
+   * @return when the number of threads in the {@code I/O} pool is greater than {@link #getIoCorePoolSize()}, this is the maximum
+   *         time (in milliseconds) that excess idle threads will wait for new tasks before terminating.
+   */
+  OptionalLong getIoKeepAlive();
+
+  /**
+   * @return the number of threads to keep in the {@code cpu_intensive} pool, even if they are idle.
+   */
+  OptionalInt getCpuIntensivePoolSize();
+
+  /**
+   * @return the size of the queue to use for holding {@code cpu_intensive} tasks before they are executed.
+   */
+  OptionalInt getCpuIntensiveQueueSize();
+
+  /**
+   * @return the prefix to prepend to the names of the threads of the pools created for a scheduler with this configuration.
+   */
+  String getThreadNamePrefix();
+}

--- a/src/main/java/org/mule/runtime/api/scheduler/SchedulerPoolsConfigFactory.java
+++ b/src/main/java/org/mule/runtime/api/scheduler/SchedulerPoolsConfigFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.scheduler;
+
+import java.util.Optional;
+
+/**
+ * Provides an instance of {@link SchedulerPoolsConfig} to use when building the infrastructure for the {@link Scheduler}s.
+ * 
+ * @since 1.0
+ */
+public interface SchedulerPoolsConfigFactory {
+
+  /**
+   * @return the {@link SchedulerPoolsConfig} to use, or {@link Optional#empty()} to indicate that it is the responsability of the
+   *         caller to provide the configuration.
+   */
+  Optional<SchedulerPoolsConfig> getConfig();
+
+}

--- a/src/main/java/org/mule/runtime/api/scheduler/SchedulerService.java
+++ b/src/main/java/org/mule/runtime/api/scheduler/SchedulerService.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.scheduler;
+
+import org.mule.runtime.api.service.Service;
+
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+
+/**
+ * Provides access to the different schedulers and thread pools that exist in the Mule runtime, allowing an artifact to schedule
+ * tasks on those.
+ * <p>
+ * This interface provides access to different schedulers, each with its own configured tuning options, optimized for some
+ * specific kind of work. Artifacts that need to dispatch tasks need to carefully determine which scheduler best fits the nature
+ * of the task in order to keep the resources usage and the impact on other artifacts at a minimum.
+ * <p>
+ * The {@link Scheduler}s returned by methods in the implementations must provide access the the thread pools in the Mule Runtime
+ * that have the expected tuning configuration. Each {@link Scheduler} will have its own lifecycle, managed by its user and NOT
+ * this service.
+ *
+ * @since 1.0
+ */
+public interface SchedulerService extends Service {
+
+  /**
+   * Builds a fresh {@link Scheduler} with a default configuration for light CPU tasks. The returned {@link Scheduler} is backed
+   * by the Mule runtime cpu-light executor, which is shared by all {@link Scheduler}s returned by this method.
+   * <p>
+   * A task is considered {@code cpu-light} if it doesn't block at any time and its duration is less than 10 milliseconds.
+   * <p>
+   * Implementations must get the appropriate config from the runtime context to build the target {@link Scheduler}. This method
+   * must act only as a delegate of {@link #cpuLightScheduler(SchedulerConfig, SchedulerPoolsConfigFactory)}.
+   *
+   * @return a scheduler that runs {@code cpu-light} tasks.
+   */
+  Scheduler cpuLightScheduler();
+
+  /**
+   * Builds a fresh {@link Scheduler} with a default configuration for blocking I/O tasks. The returned {@link Scheduler} is
+   * backed by the Mule runtime blocking I/O executor, which is shared by all {@link Scheduler}s returned by this method.
+   * <p>
+   * A task is considered {@code blocking I/O} if it spends most of it's clock duration blocked due to I/O operations.
+   * <p>
+   * Implementations must get the appropriate config from the runtime context to build the target {@link Scheduler}. This method
+   * must act only as a delegate of {@link #ioScheduler(SchedulerConfig, SchedulerPoolsConfigFactory)}.
+   *
+   * @return a scheduler that runs {@code blocking I/O} tasks.
+   */
+  Scheduler ioScheduler();
+
+  /**
+   * Builds a fresh {@link Scheduler} with a default configuration for heavy computation or CPU intensive tasks. The returned
+   * {@link Scheduler} is backed by the Mule runtime computation executor, which is shared by all {@link Scheduler}s returned by
+   * this method.
+   * <p>
+   * A task is considered a {@code CPU intensive} if its duration is more than 10 milliseconds and less than 20% of its clock time
+   * is due to blocking.
+   * <p>
+   * Implementations must get the appropriate config from the runtime context to build the target {@link Scheduler}. This method
+   * must act only as a delegate of {@link #cpuIntensiveScheduler(SchedulerConfig, SchedulerPoolsConfigFactory)}.
+   *
+   * @return a scheduler that runs {@code CPU intensive} tasks.
+   */
+  Scheduler cpuIntensiveScheduler();
+
+  /**
+   * Builds a fresh {@link Scheduler} for light CPU tasks. The returned {@link Scheduler} is backed by the Mule runtime cpu-light
+   * executor, which is shared by all {@link Scheduler}s returned by this method.
+   * <p>
+   * A task is considered {@code cpu-light} if it doesn't block at any time and its duration is less than 10 milliseconds.
+   * <p>
+   * If the provided {@code config} has {@code maxConcurrentTasks} set, exceeding tasks will block the caller, until a running
+   * task is finished.
+   *
+   * @param config allows customization of the returned scheduler.
+   *
+   * @return a scheduler that runs {@code cpu-light} tasks.
+   */
+  Scheduler cpuLightScheduler(SchedulerConfig config);
+
+  /**
+   * Builds a fresh {@link Scheduler} for blocking I/O tasks. The returned {@link Scheduler} is backed by the Mule runtime
+   * blocking I/O executor, which is shared by all {@link Scheduler}s returned by this method.
+   * <p>
+   * A task is considered {@code blocking I/O} if it spends most of it's clock duration blocked due to I/O operations.
+   * <p>
+   * If the provided {@code config} has {@code maxConcurrentTasks} set, exceeding tasks will block the caller, until a running
+   * task is finished.
+   *
+   * @param config allows customization of the returned scheduler.
+   *
+   * @return a scheduler that runs {@code blocking I/O} tasks.
+   */
+  Scheduler ioScheduler(SchedulerConfig config);
+
+  /**
+   * Builds a fresh {@link Scheduler} for heavy computation or CPU intensive tasks. The returned {@link Scheduler} is backed by
+   * the Mule runtime computation executor, which is shared by all {@link Scheduler}s returned by this method.
+   * <p>
+   * A task is considered a {@code CPU intensive} if its duration is more than 10 milliseconds and less than 20% of its clock time
+   * is due to blocking.
+   * <p>
+   * If the provided {@code config} has {@code maxConcurrentTasks} set, exceeding tasks will block the caller, until a running
+   * task is finished.
+   *
+   * @param config allows customization of the returned scheduler.
+   *
+   * @return a scheduler that runs {@code CPU intensive} tasks.
+   */
+  Scheduler cpuIntensiveScheduler(SchedulerConfig config);
+
+  /**
+   * Builds a fresh {@link Scheduler} for light CPU tasks. The returned {@link Scheduler} is backed by the Mule runtime cpu-light
+   * executor, which is shared by all {@link Scheduler}s returned by this method.
+   * <p>
+   * A task is considered {@code cpu-light} if it doesn't block at any time and its duration is less than 10 milliseconds.
+   * <p>
+   * If the provided {@code config} has {@code maxConcurrentTasks} set, exceeding tasks will block the caller, until a running
+   * task is finished.
+   *
+   * @param config allows customization of the returned scheduler.
+   * @param poolsConfigFactory the configuration to use for the thread pools that the schedulers use.
+   *
+   * @return a scheduler that runs {@code cpu-light} tasks.
+   */
+  Scheduler cpuLightScheduler(SchedulerConfig config, SchedulerPoolsConfigFactory poolsConfigFactory);
+
+  /**
+   * Builds a fresh {@link Scheduler} for blocking I/O tasks. The returned {@link Scheduler} is backed by the Mule runtime
+   * blocking I/O executor, which is shared by all {@link Scheduler}s returned by this method.
+   * <p>
+   * A task is considered {@code blocking I/O} if it spends most of it's clock duration blocked due to I/O operations.
+   * <p>
+   * If the provided {@code config} has {@code maxConcurrentTasks} set, exceeding tasks will block the caller, until a running
+   * task is finished.
+   *
+   * @param config allows customization of the returned scheduler.
+   * @param poolsConfigFactory the configuration to use for the thread pools that the schedulers use.
+   *
+   * @return a scheduler that runs {@code blocking I/O} tasks.
+   */
+  Scheduler ioScheduler(SchedulerConfig config, SchedulerPoolsConfigFactory poolsConfigFactory);
+
+  /**
+   * Builds a fresh {@link Scheduler} for heavy computation or CPU intensive tasks. The returned {@link Scheduler} is backed by
+   * the Mule runtime computation executor, which is shared by all {@link Scheduler}s returned by this method.
+   * <p>
+   * A task is considered a {@code CPU intensive} if its duration is more than 10 milliseconds and less than 20% of its clock time
+   * is due to blocking.
+   * <p>
+   * If the provided {@code config} has {@code maxConcurrentTasks} set, exceeding tasks will block the caller, until a running
+   * task is finished.
+   *
+   * @param config allows customization of the returned scheduler.
+   * @param poolsConfigFactory the configuration to use for the thread pools that the schedulers use.
+   *
+   * @return a scheduler that runs {@code CPU intensive} tasks.
+   */
+  Scheduler cpuIntensiveScheduler(SchedulerConfig config, SchedulerPoolsConfigFactory poolsConfigFactory);
+
+  /**
+   * Builds a fresh {@link Scheduler} for custom tasks. The returned {@link Scheduler} is backed by an
+   * {@link java.util.concurrent.ExecutorService} built with the given {@code corePoolSize} threads and a
+   * {@link SynchronousQueue}.
+   *
+   * @param config allows customization of the returned scheduler.
+   * @return a scheduler whose threads manage {@code custom} tasks.
+   */
+  Scheduler customScheduler(SchedulerConfig config);
+
+  /**
+   * Builds a fresh {@link Scheduler} for custom tasks. The returned {@link Scheduler} is backed by an
+   * {@link java.util.concurrent.ExecutorService} built with the given {@code corePoolSize} threads and a
+   * {@link LinkedBlockingQueue} with the given {@code queueSize}.
+   *
+   * @param config allows customization of the returned scheduler.
+   * @return a scheduler whose threads manage {@code custom} tasks.
+   */
+  Scheduler customScheduler(SchedulerConfig config, int queueSize);
+
+  /**
+   * Provides a read-only view of all currently active {@link Scheduler}s created through this service.
+   *
+   * @return a {@link List} of {@link SchedulerView}s for all currently active {@link Scheduler}s.
+   */
+  List<SchedulerView> getSchedulers();
+
+}

--- a/src/main/java/org/mule/runtime/api/store/ObjectStoreToMapAdapter.java
+++ b/src/main/java/org/mule/runtime/api/store/ObjectStoreToMapAdapter.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.store;
+
+import org.mule.runtime.api.exception.MuleRuntimeException;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Adapts the object store interface to a map interface so the client doesn't have to deal with all the ObjectStoreExceptions
+ * thrown by ObjectStore.
+ * <p>
+ * This class provides limited functionality from the Map interface. It does not support some methods (see methods javadoc) that
+ * can have a big impact in performance due the underlying object store being used.
+ * <p>
+ * The object store provided will be access for completing the map operations but the whole lifecycle of the provided object store
+ * must be handled by the user.
+ * <p>
+ * Operations of this map are not thread safe so the user must synchronize access to this map properly.
+ *
+ * @param <T> the generic type of the instances contained in the {@link ObjectStore}
+ *
+ * @since 1.0
+ */
+public abstract class ObjectStoreToMapAdapter<T extends Serializable> implements Map<String, T> {
+
+  protected abstract ObjectStore<T> getObjectStore();
+
+  @Override
+  public int size() {
+    try {
+      return getObjectStore().allKeys().size();
+    } catch (ObjectStoreException e) {
+      throw new MuleRuntimeException(e);
+    }
+  }
+
+  @Override
+  public boolean isEmpty() {
+    try {
+      return getObjectStore().allKeys().isEmpty();
+    } catch (ObjectStoreException e) {
+      throw new MuleRuntimeException(e);
+    }
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    try {
+      return getObjectStore().contains((String) key);
+    } catch (ObjectStoreException e) {
+      throw new MuleRuntimeException(e);
+    }
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    throw new UnsupportedOperationException("Map adapter for object store does not support contains value");
+  }
+
+  @Override
+  public T get(Object key) {
+    try {
+      if (!getObjectStore().contains((String) key)) {
+        return null;
+      }
+      return getObjectStore().retrieve((String) key);
+    } catch (ObjectStoreException e) {
+      throw new MuleRuntimeException(e);
+    }
+  }
+
+  @Override
+  public T put(String key, T value) {
+    T previousValue = null;
+    try {
+      if (getObjectStore().contains(key)) {
+        previousValue = getObjectStore().retrieve(key);
+        getObjectStore().remove(key);
+      }
+      if (value != null) {
+        getObjectStore().store(key, value);
+      }
+      return previousValue;
+    } catch (ObjectStoreException e) {
+      throw new MuleRuntimeException(e);
+    }
+  }
+
+  @Override
+  public T remove(Object key) {
+    try {
+      if (getObjectStore().contains((String) key)) {
+        return getObjectStore().remove((String) key);
+      }
+    } catch (ObjectStoreException e) {
+      throw new MuleRuntimeException(e);
+    }
+    return null;
+  }
+
+  @Override
+  public void putAll(Map<? extends String, ? extends T> mapToAdd) {
+    for (String key : mapToAdd.keySet()) {
+      put(key, mapToAdd.get(key));
+    }
+  }
+
+  @Override
+  public void clear() {
+    try {
+      getObjectStore().clear();
+    } catch (ObjectStoreException e) {
+      throw new MuleRuntimeException(e);
+    }
+  }
+
+  @Override
+  public Set<String> keySet() {
+    try {
+      final List<String> allKeys = getObjectStore().allKeys();
+      return new HashSet(allKeys);
+    } catch (ObjectStoreException e) {
+      throw new MuleRuntimeException(e);
+    }
+  }
+
+  /**
+   * This method is not supported for performance reasons
+   */
+  @Override
+  public Collection<T> values() {
+    throw new UnsupportedOperationException("ObjectStoreToMapAdapter does not support values() method");
+  }
+
+  /**
+   * This method is not supported for performance reasons
+   */
+  @Override
+  public Set<Entry<String, T>> entrySet() {
+    throw new UnsupportedOperationException("ObjectStoreToMapAdapter does not support entrySet() method");
+  }
+}

--- a/src/main/java/org/mule/runtime/api/store/SimpleMemoryObjectStore.java
+++ b/src/main/java/org/mule/runtime/api/store/SimpleMemoryObjectStore.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.store;
+
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SimpleMemoryObjectStore<T extends Serializable> extends TemplateObjectStore<T> implements ObjectStore<T> {
+
+  private Map<String, T> map = new ConcurrentHashMap<>();
+
+  @Override
+  public boolean isPersistent() {
+    return false;
+  }
+
+  @Override
+  protected boolean doContains(String key) throws ObjectStoreException {
+    return map.containsKey(key);
+  }
+
+  @Override
+  protected void doStore(String key, T value) throws ObjectStoreException {
+    if (value == null) {
+      throw new ObjectStoreException(createStaticMessage("The required object/property \"value\" is null"));
+    }
+
+    map.put(key, value);
+  }
+
+  @Override
+  protected T doRetrieve(String key) throws ObjectStoreException {
+    return map.get(key);
+  }
+
+  @Override
+  public void clear() throws ObjectStoreException {
+    this.map.clear();
+  }
+
+  @Override
+  protected T doRemove(String key) {
+    return map.remove(key);
+  }
+
+  @Override
+  public void open() throws ObjectStoreException {
+    // this is a no-op
+  }
+
+  @Override
+  public void close() throws ObjectStoreException {
+    // this is a no-op
+  }
+
+  @Override
+  public List<String> allKeys() throws ObjectStoreException {
+    return new ArrayList<>(map.keySet());
+  }
+}

--- a/src/main/java/org/mule/runtime/api/time/TimeSupplier.java
+++ b/src/main/java/org/mule/runtime/api/time/TimeSupplier.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.time;
+
+import java.util.function.Supplier;
+
+/**
+ * A {@link Supplier} which provides a unified time in milliseconds.
+ *
+ * @since 4.0
+ */
+public interface TimeSupplier extends Supplier<Long> {
+
+  /**
+   * Returns {@link System#currentTimeMillis()}
+   *
+   * @return the current time in milliseconds
+   */
+  @Override
+  Long get();
+}

--- a/src/main/java/org/mule/runtime/api/util/collection/Collectors.java
+++ b/src/main/java/org/mule/runtime/api/util/collection/Collectors.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.api.util.collection;
+
+import org.mule.runtime.internal.util.collection.ImmutableListCollector;
+import org.mule.runtime.internal.util.collection.ImmutableMapCollector;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collector;
+
+/**
+ * Provides different implementations of {@link Collector}
+ *
+ * @since 1.0
+ */
+public class Collectors {
+
+  private Collectors() {}
+
+  /**
+   * Returns a {@code Collector} that accumulates the input elements into an immutable {@code List}.
+   *
+   * @param <T> the type of the input elements
+   * @return a {@code Collector} which collects all the input elements into an immutable {@code List}, in encounter order
+   */
+  public static <T> Collector<T, ?, List<T>> toImmutableList() {
+    return new ImmutableListCollector<>();
+  }
+
+  /**
+   * Returns a {@code Collector} that accumulates elements into an immutable {@code Map} whose keys and values are the result of
+   * applying the provided mapping functions to the input elements.
+   *
+   * @param <T> the type of the input elements
+   * @param <K> the output type of the key mapping function
+   * @param <U> the output type of the value mapping function
+   * @param keyMapper a mapping function to produce keys
+   * @param valueMapper a mapping function to produce values
+   * @return a {@code Collector} which collects elements into a {@code Map}
+   * whose keys and values are the result of applying mapping functions to
+   * the input elements
+   */
+  public static <T, K, V> Collector<T, ?, Map<K, V>> toImmutableMap(Function<T, K> keyMapper, Function<T, V> valueMapper) {
+    return new ImmutableMapCollector<>(keyMapper, valueMapper);
+  }
+}

--- a/src/main/java/org/mule/runtime/internal/util/collection/ImmutableEntry.java
+++ b/src/main/java/org/mule/runtime/internal/util/collection/ImmutableEntry.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.internal.util.collection;
+
+import java.util.Map;
+
+/**
+ * Immutable {@link Map.Entry} implementation.
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value
+ *
+ * @since 1.0
+ */
+public class ImmutableEntry<K, V> implements Map.Entry<K, V> {
+
+  private final Map.Entry<K, V> entry;
+
+  public ImmutableEntry(Map.Entry<K, V> entry) {
+    this.entry = entry;
+  }
+
+  @Override
+  public K getKey() {
+    return entry.getKey();
+  }
+
+  @Override
+  public V getValue() {
+    return entry.getValue();
+  }
+
+  @Override
+  public V setValue(V value) {
+    throw new UnsupportedOperationException("It's not possible to update a map entry result of a map iteration");
+  }
+}

--- a/src/main/java/org/mule/runtime/internal/util/collection/ImmutableListCollector.java
+++ b/src/main/java/org/mule/runtime/internal/util/collection/ImmutableListCollector.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.internal.util.collection;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+/**
+ * {@link Collector} that returns a {@link ImmutableList}
+ *
+ * @param <T> the generic type of the elements in the list
+ * @since 1.0
+ */
+public class ImmutableListCollector<T> implements Collector<T, ImmutableList.Builder<T>, List<T>> {
+
+  @Override
+  public Supplier<ImmutableList.Builder<T>> supplier() {
+    return ImmutableList::builder;
+  }
+
+  @Override
+  public BiConsumer<ImmutableList.Builder<T>, T> accumulator() {
+    return (builder, value) -> builder.add(value);
+  }
+
+  @Override
+  public BinaryOperator<ImmutableList.Builder<T>> combiner() {
+    return (left, right) -> {
+      left.addAll(right.build());
+      return left;
+    };
+  }
+
+  @Override
+  public Function<ImmutableList.Builder<T>, List<T>> finisher() {
+    return ImmutableList.Builder::build;
+  }
+
+  @Override
+  public Set<Characteristics> characteristics() {
+    return ImmutableSet.of();
+  }
+}

--- a/src/main/java/org/mule/runtime/internal/util/collection/ImmutableMapCollector.java
+++ b/src/main/java/org/mule/runtime/internal/util/collection/ImmutableMapCollector.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.internal.util.collection;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+/**
+ * {@link Collector} which returns an {@link ImmutableMap}
+ *
+ * @param <T> the generic type of input elements
+ * @param <K> the output map's key type
+ * @param <V> the output map's values type
+ * @since 1.0
+ */
+public class ImmutableMapCollector<T, K, V> implements Collector<T, ImmutableMap.Builder<K, V>, Map<K, V>> {
+
+  private final Function<T, K> keyMapper;
+  private final Function<T, V> valueMapper;
+
+  /**
+   * Creates a new instance
+   *
+   * @param keyMapper a mapping function to produce keys
+   * @param valueMapper a mapping function to produce values
+   */
+  public ImmutableMapCollector(Function<T, K> keyMapper, Function<T, V> valueMapper) {
+    this.keyMapper = keyMapper;
+    this.valueMapper = valueMapper;
+  }
+
+  @Override
+  public Supplier<ImmutableMap.Builder<K, V>> supplier() {
+    return ImmutableMap::builder;
+  }
+
+  @Override
+  public BiConsumer<ImmutableMap.Builder<K, V>, T> accumulator() {
+    return (builder, value) -> builder.put(keyMapper.apply(value), valueMapper.apply(value));
+  }
+
+  @Override
+  public BinaryOperator<ImmutableMap.Builder<K, V>> combiner() {
+    return (left, right) -> left.putAll(right.build());
+  }
+
+  @Override
+  public Function<ImmutableMap.Builder<K, V>, Map<K, V>> finisher() {
+    return ImmutableMap.Builder::build;
+  }
+
+  @Override
+  public Set<Characteristics> characteristics() {
+    return ImmutableSet.of();
+  }
+}

--- a/src/main/java/org/mule/runtime/internal/util/collection/ImmutableSetCollector.java
+++ b/src/main/java/org/mule/runtime/internal/util/collection/ImmutableSetCollector.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.internal.util.collection;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+/**
+ * {@link Collector} that returns a {@link ImmutableSet}
+ *
+ * @param <T> the generic type of the elements in the {@link Set}
+ * @since 1.0
+ */
+public class ImmutableSetCollector<T> implements Collector<T, ImmutableSet.Builder<T>, Set<T>> {
+
+  @Override
+  public Supplier<ImmutableSet.Builder<T>> supplier() {
+    return ImmutableSet::builder;
+  }
+
+  @Override
+  public BiConsumer<ImmutableSet.Builder<T>, T> accumulator() {
+    return (builder, value) -> builder.add(value);
+  }
+
+  @Override
+  public BinaryOperator<ImmutableSet.Builder<T>> combiner() {
+    return (left, right) -> {
+      left.addAll(right.build());
+      return left;
+    };
+  }
+
+  @Override
+  public Function<ImmutableSet.Builder<T>, Set<T>> finisher() {
+    return ImmutableSet.Builder::build;
+  }
+
+  @Override
+  public Set<Characteristics> characteristics() {
+    return ImmutableSet.of(Characteristics.UNORDERED);
+  }
+}

--- a/src/main/resources/META-INF/mule-module.properties
+++ b/src/main/resources/META-INF/mule-module.properties
@@ -60,8 +60,10 @@ artifact.export.classPackages=org.mule.runtime.api.app.declaration,\
                               org.mule.runtime.api.streaming.bytes,\
                               org.mule.runtime.api.streaming.object,\
                               org.mule.runtime.api.streaming.exception,\
+                              org.mule.runtime.api.time,\
                               org.mule.runtime.api.tls,\
                               org.mule.runtime.api.transformation,\
                               org.mule.runtime.api.tx,\
                               org.mule.runtime.api.util,\
+                              org.mule.runtime.api.util.collection,\
                               javax.inject


### PR DESCRIPTION
_ Moving classes out of core's api package
_ When possible, classes where moved to internal
_ Moved to privileged when classes where required on compatibility
_ Moved to other module's API when needed on tests or it made sense
_ Deleted if not needed anymore
_ Some tests were ignored as they use an internal class and need refactoring