### PR TITLE
MULE-13210: Allow Core Extensions to Inject container services

### DIFF
--- a/src/main/java/org/mule/runtime/api/service/ServiceRepository.java
+++ b/src/main/java/org/mule/runtime/api/service/ServiceRepository.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.api.service;
+
+import java.util.List;
+
+/**
+ * Provides access to the services available in the container.
+ *
+ * @since 1.1
+ */
+public interface ServiceRepository {
+
+  /**
+   * Provides access to the services available in the container.
+   *
+   * @return a non null list of services.
+   */
+  List<Service> getServices();
+}


### PR DESCRIPTION
_ Enabling injection of ServiceRepository and service instances on core extensions by defining fields or setters annotated with @Inject