### PR TITLE
MULE-11659: Add tool to ensure that Mule API is backward compatible o…

### DIFF
--- a/api-ignored.json
+++ b/api-ignored.json
@@ -1,0 +1,46 @@
+{
+  "revapi": {
+    "ignore": [
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.api.message.Message.CollectionBuilder org.mule.runtime.api.message.Message.CollectionBuilder::attributes(org.mule.runtime.api.metadata.TypedValue<?>)",
+        "new": "method org.mule.runtime.api.message.Message.Builder org.mule.runtime.api.message.Message.Builder::attributes(org.mule.runtime.api.metadata.TypedValue<?>) @ org.mule.runtime.api.message.Message.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.api.message.Message.CollectionBuilder org.mule.runtime.api.message.Message.CollectionBuilder::attributesMediaType(org.mule.runtime.api.metadata.MediaType)",
+        "new": "method org.mule.runtime.api.message.Message.Builder org.mule.runtime.api.message.Message.Builder::attributesMediaType(org.mule.runtime.api.metadata.MediaType) @ org.mule.runtime.api.message.Message.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.api.message.Message.CollectionBuilder org.mule.runtime.api.message.Message.CollectionBuilder::attributesValue(java.lang.Object)",
+        "new": "method org.mule.runtime.api.message.Message.Builder org.mule.runtime.api.message.Message.Builder::attributesValue(java.lang.Object) @ org.mule.runtime.api.message.Message.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.api.message.Message.CollectionBuilder org.mule.runtime.api.message.Message.CollectionBuilder::mediaType(org.mule.runtime.api.metadata.MediaType)",
+        "new": "method org.mule.runtime.api.message.Message.Builder org.mule.runtime.api.message.Message.Builder::mediaType(org.mule.runtime.api.metadata.MediaType) @ org.mule.runtime.api.message.Message.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.api.message.Message.CollectionBuilder org.mule.runtime.api.message.Message.CollectionBuilder::nullAttributesValue()",
+        "new": "method org.mule.runtime.api.message.Message.Builder org.mule.runtime.api.message.Message.Builder::nullAttributesValue() @ org.mule.runtime.api.message.Message.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method org.mule.runtime.api.message.Message.MapBuilder org.mule.runtime.api.message.Message.PayloadBuilder::mapValue(java.util.Map, java.lang.Class<?>, java.lang.Class<?>)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method org.mule.runtime.api.tls.TlsRevocationCheckBuilder org.mule.runtime.api.tls.TlsContextFactoryBuilder::revocationCheck()",
+        "justification": "MULE-14280: API broken by MULE-14082"
+      }
+    ]
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
         <jacoco.version>0.7.9</jacoco.version>
 
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
+        <oldMuleArtifactVersion>1.0.0</oldMuleArtifactVersion>
     </properties>
 
     <dependencies>
@@ -415,6 +416,55 @@
             <plugin>
                 <groupId>io.qameta.allure</groupId>
                 <artifactId>allure-maven</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+                <version>0.9.5</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.mule.tools.maven</groupId>
+                        <artifactId>mule-revapi-extension</artifactId>
+                        <version>1.0.0-SNAPSHOT</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <oldVersion>${oldMuleArtifactVersion}</oldVersion>
+                    <failOnUnresolvedArtifacts>true</failOnUnresolvedArtifacts>
+                    <failOnMissingConfigurationFiles>false</failOnMissingConfigurationFiles>
+                    <analysisConfiguration><![CDATA[
+                                {
+                                    "revapi" : {
+                                        "java" : {
+                                            "missing-classes" : {
+                                                "behavior" : "report"
+                                            }
+                                        },
+                                        "semver": {
+                                          "ignore": {
+                                            "enabled": true,
+                                            "versionIncreaseAllows" : {
+                                              "major" : "breaking",
+                                              "minor" : "nonBreaking",
+                                              "patch" : "equivalent"
+                                            }
+                                          }
+                                        }
+                                    }
+                                }
+                            ]]></analysisConfiguration>
+                    <analysisConfigurationFiles combine.children="append">
+                        <configurationFile>
+                            <path>api-ignored.json</path>
+                        </configurationFile>
+                    </analysisConfigurationFiles>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>api-check</id>
+                        <goals><goal>check</goal></goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
…n each release

_ Adding profile to run the Mule module and Revapi plugins only when a Mule module is declared.
_ Adding Revapi exclusions to temporarily ignore broken API