### PR TITLE
MULE-15932: System dependent line separators should be used for building Mule exception summary message

### DIFF
--- a/src/main/java/org/mule/runtime/api/exception/MuleException.java
+++ b/src/main/java/org/mule/runtime/api/exception/MuleException.java
@@ -205,7 +205,8 @@ public abstract class MuleException extends Exception {
     buf.append("Message               : ").append(message).append(lineSeparator());
 
     for (String key : SUMMARY_LOGGING_KEYS) {
-      buf.append(format("%s%s: %s\n", key, getColonMatchingPad(key), info.getOrDefault(key, MISSING_DEFAULT_VALUE)));
+      buf.append(format("%s%s: %s", key, getColonMatchingPad(key), info.getOrDefault(key, MISSING_DEFAULT_VALUE)));
+      buf.append(lineSeparator());
     }
     buf.append(lineSeparator())
         .append("  (set debug level logging or '-D" + MULE_VERBOSE_EXCEPTIONS + "=true' for everything)")


### PR DESCRIPTION
- Refactor on `org.mule.runtime.api.exception.MuleException#getSummaryMessage` method
- This issue is the root cause of the `mule-aggregators-module`tests failing on Windows 