### PR TITLE
MULE-17672: Make DefaultTypedComponentIdentifier#hashCode consistent across runs

### DIFF
--- a/src/main/java/org/mule/runtime/api/component/DefaultTypedComponentIdentifier.java
+++ b/src/main/java/org/mule/runtime/api/component/DefaultTypedComponentIdentifier.java
@@ -19,17 +19,19 @@ class DefaultTypedComponentIdentifier implements TypedComponentIdentifier, Seria
 
   private DefaultTypedComponentIdentifier() {}
 
+  @Override
   public ComponentIdentifier getIdentifier() {
     return identifier;
   }
 
+  @Override
   public ComponentType getType() {
     return type;
   }
 
   public static class Builder implements TypedComponentIdentifier.Builder {
 
-    private DefaultTypedComponentIdentifier typedComponentIdentifier = new DefaultTypedComponentIdentifier();
+    private final DefaultTypedComponentIdentifier typedComponentIdentifier = new DefaultTypedComponentIdentifier();
 
     @Override
     public TypedComponentIdentifier.Builder identifier(ComponentIdentifier identifier) {
@@ -37,11 +39,13 @@ class DefaultTypedComponentIdentifier implements TypedComponentIdentifier, Seria
       return this;
     }
 
+    @Override
     public Builder type(ComponentType type) {
       typedComponentIdentifier.type = type;
       return this;
     }
 
+    @Override
     public TypedComponentIdentifier build() {
       checkState(typedComponentIdentifier.identifier != null, "identifier cannot be null");
       checkState(typedComponentIdentifier.type != null,
@@ -70,7 +74,7 @@ class DefaultTypedComponentIdentifier implements TypedComponentIdentifier, Seria
   @Override
   public int hashCode() {
     int result = getIdentifier().hashCode();
-    result = 31 * result + getType().hashCode();
+    result = 31 * result + Integer.hashCode(getType().ordinal());
     return result;
   }
 

--- a/src/main/java/org/mule/runtime/api/meta/model/stereotype/HasStereotypeModel.java
+++ b/src/main/java/org/mule/runtime/api/meta/model/stereotype/HasStereotypeModel.java
@@ -18,7 +18,7 @@ import org.mule.api.annotation.NoImplement;
 public interface HasStereotypeModel {
 
   /**
-   * @return The {@link StereotypeModel stereotypes} which apply to this model
+   * @return The {@link StereotypeModel stereotypes} which apply to this model. Not null.
    */
   StereotypeModel getStereotype();
 

--- a/src/main/java/org/mule/runtime/api/meta/model/stereotype/StereotypeModel.java
+++ b/src/main/java/org/mule/runtime/api/meta/model/stereotype/StereotypeModel.java
@@ -42,7 +42,8 @@ public interface StereotypeModel {
   Optional<StereotypeModel> getParent();
 
   /**
-   * @return if {@code this}
+   * @return {@code true} if {@code this} stereotype or any of its ancestors is equal to the provided {@code other}
+   *         {@link StereotypeModel}, {@code false} otherwise.
    */
   boolean isAssignableTo(StereotypeModel other);
 }


### PR DESCRIPTION
* Also piggyback some improvements in some javadocs