### PR TITLE
MULE-18063: Revert changes

### DIFF
--- a/src/main/java/org/mule/runtime/api/deployment/management/ComponentInitialStateManager.java
+++ b/src/main/java/org/mule/runtime/api/deployment/management/ComponentInitialStateManager.java
@@ -18,6 +18,8 @@ public interface ComponentInitialStateManager {
   /**
    * This is a configuration property that can be set at deployment time to disable the scheduler message sources to be started
    * when deploying an application.
+   * 
+   * @deprecated Please use {@link org.mule.runtime.api.util.MuleSystemProperties#DISABLE_SCHEDULER_SOURCES_PROPERTY} instead.
    */
   String DISABLE_SCHEDULER_SOURCES_PROPERTY = "mule.config.scheduler.disabled";
 

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -109,8 +109,8 @@ public final class MuleSystemProperties {
   public static final String DATA_WEAVE_SCRIPT_PROCESSING_TYPE = SYSTEM_PROPERTY_PREFIX + "dwScript.processingType";
 
   /**
-   * If set, Mule will precompile DataWeave expressions at application startup time and fail the deployment if any of them
-   * cannot be compiled.
+   * If set, Mule will precompile DataWeave expressions at application startup time and fail the deployment if any of them cannot
+   * be compiled.
    *
    * @since 1.3.0
    */
@@ -125,6 +125,12 @@ public final class MuleSystemProperties {
    */
   public static final String MULE_LIFECYCLE_FAIL_ON_FIRST_DISPOSE_ERROR =
       SYSTEM_PROPERTY_PREFIX + "lifecycle.failOnFirstDisposeError";
+
+  /**
+   * This is a configuration property that can be set at deployment time to disable the scheduler message sources to be started
+   * when deploying an application.
+   */
+  public static final String DISABLE_SCHEDULER_SOURCES_PROPERTY = "mule.config.scheduler.disabled";
 
   /**
    * @return {@code true} if the {@link #TESTING_MODE_PROPERTY_NAME} property has been set (regardless of the value)

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -127,13 +127,6 @@ public final class MuleSystemProperties {
       SYSTEM_PROPERTY_PREFIX + "lifecycle.failOnFirstDisposeError";
 
   /**
-   * If set to true, schedulers flow sources won't start.
-   *
-   * @since 1.3.0
-   */
-  public static final String MULE_DISABLE_SCHEDULERS = SYSTEM_PROPERTY_PREFIX + "schedulers.disable";
-
-  /**
    * @return {@code true} if the {@link #TESTING_MODE_PROPERTY_NAME} property has been set (regardless of the value)
    */
   public static boolean isTestingMode() {

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -109,8 +109,8 @@ public final class MuleSystemProperties {
   public static final String DATA_WEAVE_SCRIPT_PROCESSING_TYPE = SYSTEM_PROPERTY_PREFIX + "dwScript.processingType";
 
   /**
-   * If set, Mule will precompile DataWeave expressions at application startup time and fail the deployment if any of them cannot
-   * be compiled.
+   * If set, Mule will precompile DataWeave expressions at application startup time and fail the deployment if any of them
+   * cannot be compiled.
    *
    * @since 1.3.0
    */

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -130,7 +130,7 @@ public final class MuleSystemProperties {
    * This is a configuration property that can be set at deployment time to disable the scheduler message sources to be started
    * when deploying an application.
    */
-  public static final String DISABLE_SCHEDULER_SOURCES_PROPERTY = "mule.config.scheduler.disabled";
+  public static final String DISABLE_SCHEDULER_SOURCES_PROPERTY = SYSTEM_PROPERTY_PREFIX + "config.scheduler.disabled";
 
   /**
    * @return {@code true} if the {@link #TESTING_MODE_PROPERTY_NAME} property has been set (regardless of the value)


### PR DESCRIPTION
It revers changes introduced in PR #637 because this feature already exists.  Also, it deprecates the System Property DISABLE_SCHEDULER_SOURCES_PROPERTY and adds this property in the MuleSystemProperties class.