### PR TITLE
MULE-18196: Application fails to deploy when having same custom name space as that of custom policy applied (branch support/1.2.2)

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -3,6 +3,15 @@
     "revapi": {
       "ignore": [
         {
+          "code": "java.field.addedStaticField",
+          "new": "field org.mule.runtime.api.util.MuleSystemProperties.SHARE_ERROR_TYPE_REPOSITORY_PROPERTY",
+          "package": "org.mule.runtime.api.util",
+          "classSimpleName": "MuleSystemProperties",
+          "fieldName": "SHARE_ERROR_TYPE_REPOSITORY_PROPERTY",
+          "elementKind": "field",
+          "justification": "MULE-18196"
+        },
+        {
           "code": "java.method.added",
           "new": "method org.mule.runtime.api.deployment.meta.MuleApplicationModel.MuleApplicationModelBuilder org.mule.runtime.api.deployment.meta.MuleApplicationModel.MuleApplicationModelBuilder::setDomain(java.lang.String)",
           "package": "org.mule.runtime.api.deployment.meta",

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -72,6 +72,14 @@ public final class MuleSystemProperties {
   public static final String DATA_WEAVE_SCRIPT_PROCESSING_TYPE = SYSTEM_PROPERTY_PREFIX + "dwScript.processingType";
 
   /**
+   * When enabled this System Property, if an ErrorType is not found in the policy ErrorType repository, then
+   * it's used the app ErrorType repository.
+   *
+   * @since 1.3.0
+   */
+  public static final String SHARE_ERROR_TYPE_REPOSITORY_PROPERTY = SYSTEM_PROPERTY_PREFIX + "share.errorTypeRepository";
+
+  /**
    * @return {@code true} if the {@link #TESTING_MODE_PROPERTY_NAME} property has been set (regardless of the value)
    */
   public static boolean isTestingMode() {


### PR DESCRIPTION
(cherry picked from commit 5b8883a29fa5939e8cec4fc1d03a97fb54661f03)