### PR TITLE
MULE-18047: Add the component that generated a cursor provider (support/1.2.1)

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -1,7 +1,25 @@
 {
   "1.2.1": {
     "revapi": {
-      "ignore": [
+       "ignore": [
+       {
+         "code": "java.method.defaultMethodAddedToInterface",
+         "new": "method java.util.Optional<org.mule.runtime.api.component.location.ComponentLocation> org.mule.runtime.api.streaming.CursorProvider<T extends org.mule.runtime.api.streaming.Cursor>::getOriginatingLocation()",
+         "package": "org.mule.runtime.api.streaming",
+         "classSimpleName": "CursorProvider",
+         "methodName": "getOriginatingLocation",
+         "elementKind": "method",
+         "justification": "MULE-18595"
+       },
+       {
+         "code": "java.field.addedStaticField",
+         "new": "field org.mule.runtime.api.util.MuleSystemProperties.TRACK_CURSOR_PROVIDER_CLOSE_PROPERTY",
+         "package": "org.mule.runtime.api.util",
+         "classSimpleName": "MuleSystemProperties",
+         "fieldName": "TRACK_CURSOR_PROVIDER_CLOSE_PROPERTY",
+         "elementKind": "field",
+         "justification": "MULE-18595"
+       },
        {
           "code": "java.class.added",
           "new": "class org.mule.runtime.api.connection.RemoteConnectionException",

--- a/src/main/java/org/mule/runtime/api/streaming/CursorProvider.java
+++ b/src/main/java/org/mule/runtime/api/streaming/CursorProvider.java
@@ -7,7 +7,14 @@
 package org.mule.runtime.api.streaming;
 
 import org.mule.api.annotation.NoImplement;
+import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.streaming.bytes.CursorStream;
+
+import java.util.Optional;
+
+import static java.lang.Boolean.getBoolean;
+import static java.util.Optional.empty;
+import static org.mule.runtime.api.util.MuleSystemProperties.TRACK_CURSOR_PROVIDER_CLOSE_PROPERTY;
 
 /**
  * Provides instances of {@link Cursor} which allows concurrent access to a wrapped
@@ -26,7 +33,6 @@ import org.mule.runtime.api.streaming.bytes.CursorStream;
  */
 @NoImplement
 public interface CursorProvider<T extends Cursor> {
-
 
   /**
    * Creates a new {@link Cursor} of type {@code T} positioned on the very beginning of the wrapped stream.
@@ -64,5 +70,16 @@ public interface CursorProvider<T extends Cursor> {
    * @return Whether the {@link #close()} method has been invoked on {@code this} instance or not
    */
   boolean isClosed();
+
+  /**
+   * @return the {@link ComponentLocation} that describes the component where the cursor was created.
+   *
+   * @since 1.3.0
+   */
+  default Optional<ComponentLocation> getOriginatingLocation() {
+    return empty();
+  }
+
+
 }
 

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -6,6 +6,8 @@
  */
 package org.mule.runtime.api.util;
 
+import org.mule.runtime.api.streaming.CursorProvider;
+
 import static java.lang.System.getProperty;
 
 /**
@@ -70,6 +72,14 @@ public final class MuleSystemProperties {
    * Possible values are the enums in {@code ProcessingType}.
    */
   public static final String DATA_WEAVE_SCRIPT_PROCESSING_TYPE = SYSTEM_PROPERTY_PREFIX + "dwScript.processingType";
+
+  /**
+   * When enabled, this System Property tracks the stacktrace from where the {@link CursorProvider#close()} method was called. It can be used
+   * for troubleshooting purposes (for example, if someone tries to call {@link CursorProvider#openCursor()} on an already closed cursor.
+   *
+   * @since 1.2.4
+   */
+  public static final String TRACK_CURSOR_PROVIDER_CLOSE_PROPERTY = SYSTEM_PROPERTY_PREFIX + "track.cursorProvider.close";
 
   /**
    * @return {@code true} if the {@link #TESTING_MODE_PROPERTY_NAME} property has been set (regardless of the value)


### PR DESCRIPTION
… (#674)

(cherry picked from commit 784a970a5a542ec6bb7dd77cdd4e3c2dc5daef44)
(cherry picked from commit c00415caf37b2151dbdb615f00a679182391fe8b)