### PR TITLE
MULE-19110: munit:enable-flow-sources could be used to initialize

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -98,7 +98,16 @@
           "fieldName": "MULE_LOGGING_BLOCKING_CATEGORIES",
           "elementKind": "field",
           "justification": "This system property already existed. Moved to mule system properties file."
-        }      
+        },
+        {
+          "code": "java.field.addedStaticField",
+          "new": "field org.mule.runtime.api.util.MuleSystemProperties.MULE_FLOW_REFERERENCE_FIELDS_MATCH_ANY",
+          "package": "org.mule.runtime.api.util",
+          "classSimpleName": "MuleSystemProperties",
+          "fieldName": "MULE_FLOW_REFERERENCE_FIELDS_MATCH_ANY",
+          "elementKind": "field",
+          "justification": "MULE-19110"
+        }
       ]
     }
   }, 

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -224,6 +224,16 @@ public final class MuleSystemProperties {
   public static final String MULE_PRINT_STACK_TRACES_ON_DROP = SYSTEM_PROPERTY_PREFIX + "fluxSinkRecorder.printStackTracesOnDrop";
 
   /**
+   * When set to {@code true}, fields annotated with {@code org.mule.sdk.api.annotation.param.reference.FlowReference} or
+   * {@code org.mule.runtime.extension.api.annotation.param.reference.FlowReference} will match not only {@code flow} elements,
+   * but any element with the name provided in the annotated field (for instance, a {@code sub-flow}).
+   *
+   * @since 4.4, 4.3.1
+   */
+  // MULE-19110
+  public static final String MULE_FLOW_REFERERENCE_FIELDS_MATCH_ANY = SYSTEM_PROPERTY_PREFIX + "flowReference.matchesAny";
+
+  /**
    * @return {@code true} if the {@link #TESTING_MODE_PROPERTY_NAME} property has been set (regardless of the value)
    */
   public static boolean isTestingMode() {


### PR DESCRIPTION
sub-flow's in 4.2.x and lower (#751)