### PR TITLE
MULE-19219: MediaType doesn't escape characters correctly (#787)

### DIFF
--- a/src/main/java/org/mule/runtime/api/metadata/MediaType.java
+++ b/src/main/java/org/mule/runtime/api/metadata/MediaType.java
@@ -83,7 +83,8 @@ public final class MediaType implements Serializable {
 
   private static List<String> KNOWN_PARAM_NAMES =
       getProperty(MuleSystemProperties.MULE_KNOWN_MEDIA_TYPE_PARAM_NAMES) != null
-          ? asList(getProperty(MuleSystemProperties.MULE_KNOWN_MEDIA_TYPE_PARAM_NAMES).split(",")) : emptyList();
+          ? asList(getProperty(MuleSystemProperties.MULE_KNOWN_MEDIA_TYPE_PARAM_NAMES).split(","))
+          : emptyList();
 
   private final String primaryType;
   private final String subType;
@@ -115,8 +116,8 @@ public final class MediaType implements Serializable {
   /**
    * Parses a media type, defined by the developer in the App, from its string representation.
    * <p>
-   * <b>WARNING</b> This method should not be used if the source of the mediaType was not defined by the APP Developer.
-   * For example if the source is a Transport user should use {@link MediaType#parse(String)}.
+   * <b>WARNING</b> This method should not be used if the source of the mediaType was not defined by the APP Developer. For
+   * example if the source is a Transport user should use {@link MediaType#parse(String)}.
    *
    * @param mediaType String representation to be parsed
    * @throws IllegalArgumentException if the {@code mimeType} cannot be parsed.
@@ -284,6 +285,7 @@ public final class MediaType implements Serializable {
 
   /**
    * Returns true if this mimeType was defined in the Mule App by the developer
+   * 
    * @return True if defined in the Mule App
    * @since 1.2.4
    */
@@ -409,7 +411,7 @@ public final class MediaType implements Serializable {
 
     if (!params.isEmpty()) {
       params.forEach((k, v) -> {
-        buffer.append("; ").append(k).append("=\"").append(v).append("\"");
+        buffer.append("; ").append(k).append("=\"").append(quote(v)).append("\"");
       });
     }
 
@@ -424,4 +426,21 @@ public final class MediaType implements Serializable {
       out.writeObject(null);
     }
   }
+
+  private String quote(String value) {
+    int length = value.length();
+    StringBuffer buffer = new StringBuffer();
+
+    buffer.ensureCapacity(new Double(length * 1.5D).intValue());
+
+    for (int i = 0; i < length; i++) {
+      char c = value.charAt(i);
+      if (c == '\\' || c == '"') {
+        buffer.append('\\');
+      }
+      buffer.append(c);
+    }
+    return buffer.toString();
+  }
 }
+

--- a/src/test/java/org/mule/runtime/api/metadata/MediaTypeTestCase.java
+++ b/src/test/java/org/mule/runtime/api/metadata/MediaTypeTestCase.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.HashMap;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -319,6 +320,19 @@ public class MediaTypeTestCase {
     final Object deserialized = new ObjectInputStream(new ByteArrayInputStream(os.toByteArray())).readObject();
 
     assertThat(deserialized, is(withCharset));
+  }
+
+  @Test
+  public void parseAndGenerateMimeTypeCorrectly() {
+    final String originalMediaTypeString = "application/csv; quote=\"\\\"\"; separator=\"\\\\\"";
+    final MediaType mediaType = MediaType.parse(originalMediaTypeString);
+    assertThat(mediaType.getParameter("quote"), is("\""));
+    assertThat(mediaType.getParameter("separator"), is("\\"));
+    final HashMap<String, String> properties = new HashMap<>();
+    properties.put("quote", mediaType.getParameter("quote"));
+    properties.put("separator", mediaType.getParameter("separator"));
+    final MediaType newMediaType = MediaType.parse("application/csv").withParamaters(properties);
+    assertThat(newMediaType.toRfcString(), is(originalMediaTypeString));
   }
 
   @Test


### PR DESCRIPTION
* MULE-19219: MediaType doesn't escape characters correctly

* Tests that shows the bug

Co-authored-by: machaval <mariano.achaval@mulesoft.com>
(cherry picked from commit 6573cb774a1440fdf4a91153c6bda4401b93f15d)