### PR TITLE
MULE-19701: @Parameter values are not being injected when parsing XML…

### DIFF
--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -10,6 +10,7 @@ import static java.lang.System.getProperty;
 import static java.lang.System.setProperty;
 
 import org.mule.runtime.api.config.MuleRuntimeFeature;
+import org.mule.runtime.api.meta.model.declaration.fluent.ExtensionDeclarer;
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.api.streaming.CursorProvider;
 
@@ -133,6 +134,15 @@ public final class MuleSystemProperties {
   public static final String MULE_DISABLE_RESPONSE_TIMEOUT = SYSTEM_PROPERTY_PREFIX + "timeout.disable";
   public static final String MULE_ALLOW_JRE_EXTENSION = SYSTEM_PROPERTY_PREFIX + "classloading.jreExtension";
   public static final String MULE_JRE_EXTENSION_PACKAGES = SYSTEM_PROPERTY_PREFIX + "classloading.jreExtension.packages";
+  /**
+   * Comma-separated list of packages to force as registrable.
+   * <p>
+   * Refer to {@link ExtensionDeclarer#isTypeRegistrable}.
+   * 
+   * @since 1.4
+   */
+  public static final String MULE_FORCE_REGISTRABLE_EXTENSION_TYPE_PACKAGES =
+      SYSTEM_PROPERTY_PREFIX + "extension.forceRegistrableType.packages";
 
   /**
    * @deprecated Since 4.4.0 this feature was removed.

--- a/src/test/java/org/mule/runtime/api/meta/model/declaration/fuent/ExtensionDeclarerTestCase.java
+++ b/src/test/java/org/mule/runtime/api/meta/model/declaration/fuent/ExtensionDeclarerTestCase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.meta.model.declaration.fuent;
+
+import static java.util.Optional.of;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.mule.metadata.api.annotation.TypeIdAnnotation;
+import org.mule.metadata.api.model.ObjectType;
+import org.mule.metadata.api.visitor.MetadataTypeVisitor;
+import org.mule.runtime.api.meta.model.declaration.fluent.ExtensionDeclarer;
+
+import org.junit.Test;
+
+import io.qameta.allure.Issue;
+
+public class ExtensionDeclarerTestCase {
+
+  @Test
+  @Issue("MULE-19701")
+  public void registerGatewayTypes() {
+    String gwTypeFqcn = "com.mulesoft.mule.runtime.gw.GatewayType";
+    ObjectType gwObjectType = mock(ObjectType.class);
+    when(gwObjectType.getAnnotation(TypeIdAnnotation.class))
+        .thenReturn(of(new TypeIdAnnotation(gwTypeFqcn)));
+
+    doAnswer(inv -> {
+      MetadataTypeVisitor v = inv.getArgument(0);
+      v.visitObject((ObjectType) inv.getMock());
+      return null;
+    }).when(gwObjectType).accept(any());
+
+    ExtensionDeclarer declarer = new ExtensionDeclarer();
+    declarer.withType(gwObjectType);
+
+    assertThat(declarer.getDeclaration().getTypeById(gwTypeFqcn), sameInstance(gwObjectType));
+  }
+}


### PR DESCRIPTION
… (#863)

* When the parameter type has a package name starting with a Runtime prefix but is not from the runtime