### PR TITLE
MULE-19866: InterceptionApi: interceptors should be able to decide wh…

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -3,6 +3,15 @@
     "revapi": {
       "ignore": [
         {
+          "code": "java.method.defaultMethodAddedToInterface",
+          "new": "method boolean org.mule.runtime.api.interception.ProcessorInterceptor::isErrorMappingRequired(org.mule.runtime.api.component.location.ComponentLocation)",
+          "package": "org.mule.runtime.api.interception",
+          "classSimpleName": "ProcessorInterceptor",
+          "methodName": "isErrorMappingRequired",
+          "elementKind": "method",
+          "justification": "MULE-19866: interceptors should be able to decide whether to perform an extra error mapping when operation fails"
+        },
+        {
           "code": "java.class.removed",
           "old": "interface org.mule.runtime.api.profiling.ProfilingDataConsumer<T extends org.mule.runtime.api.profiling.ProfilingEventContext>",
           "package": "org.mule.runtime.api.profiling",

--- a/src/main/java/org/mule/runtime/api/interception/ProcessorInterceptor.java
+++ b/src/main/java/org/mule/runtime/api/interception/ProcessorInterceptor.java
@@ -113,4 +113,14 @@ public interface ProcessorInterceptor {
    * @param thrown   the exception thrown by the intercepted component, if any.
    */
   default void after(ComponentLocation location, InterceptionEvent event, Optional<Throwable> thrown) {}
+
+  /**
+   * Determines if the intercepted component requires the error mapping to be performed.
+   *
+   * @param location the location and identification properties of the intercepted component in the mule app configuration.
+   * @return {@code true} if the error mapping is required, {@code false} otherwise.
+   */
+  default boolean isErrorMappingRequired(ComponentLocation location) {
+    return false;
+  }
 }


### PR DESCRIPTION
…ether to perform an extra error mapping when operation fails.

Added `isErrorMappingRequired` method to `ProcessorInterceptor` interface in order for the interceptors to have a way of informing when they need an extra error mapping performed on an operation error.