### PR TITLE
MULE-19992: Private object stores should be able to be expired in secondary node (#919)

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -3,6 +3,24 @@
     "revapi": {
       "ignore": [
         {
+          "code": "java.method.added",
+          "new": "method org.mule.runtime.api.store.ObjectStoreSettings.Builder org.mule.runtime.api.store.ObjectStoreSettings.Builder::alwaysExpire(boolean)",
+          "package": "org.mule.runtime.api.store",
+          "classSimpleName": "Builder",
+          "methodName": "alwaysExpire",
+          "elementKind": "method",
+          "justification": "MULE-19992: private object stores should be able to be expired in secondary node"
+        },
+        {
+          "code": "java.method.added",
+          "new": "method boolean org.mule.runtime.api.store.ObjectStoreSettings::isAlwaysExpire()",
+          "package": "org.mule.runtime.api.store",
+          "classSimpleName": "ObjectStoreSettings",
+          "methodName": "isAlwaysExpire",
+          "elementKind": "method",
+          "justification": "MULE-19992: private object stores should be able to be expired in secondary node"
+        },
+        {
           "code": "java.method.defaultMethodAddedToInterface",
           "new": "method boolean org.mule.runtime.api.interception.ProcessorInterceptor::isErrorMappingRequired(org.mule.runtime.api.component.location.ComponentLocation)",
           "package": "org.mule.runtime.api.interception",

--- a/src/main/java/org/mule/runtime/api/store/ObjectStoreSettings.java
+++ b/src/main/java/org/mule/runtime/api/store/ObjectStoreSettings.java
@@ -85,6 +85,20 @@ public class ObjectStoreSettings {
     }
 
     /**
+     * Sets whether the entries should always be expired when the expiration thread runs. It will only be used by the runtime if
+     * expiration is configured (i.e., {@link #entryTtl(Long)} or {@link #maxEntries(Integer)} were also invoked).
+     *
+     * @param alwaysExpire whether old entries should be expired every time the expiration thread runs
+     * @return {@code this} builder
+     *
+     * @since 1.3
+     */
+    public Builder alwaysExpire(boolean alwaysExpire) {
+      product.alwaysExpire = alwaysExpire;
+      return this;
+    }
+
+    /**
      * Returns the built settings object. {@code this} instance should be discarded and no longer used
      * after invoking this method
      *
@@ -124,6 +138,7 @@ public class ObjectStoreSettings {
   private Integer maxEntries = null;
   private Long entryTTL;
   private long expirationInterval = DEFAULT_EXPIRATION_INTERVAL;
+  private boolean alwaysExpire = false;
 
   private ObjectStoreSettings() {}
 
@@ -156,5 +171,14 @@ public class ObjectStoreSettings {
    */
   public long getExpirationInterval() {
     return expirationInterval;
+  }
+
+  /**
+   * Whether old entries should be expired every time the expiration thread runs.
+   *
+   * @since 1.3
+   */
+  public boolean isAlwaysExpire() {
+    return alwaysExpire;
   }
 }


### PR DESCRIPTION
(cherry picked from commit a267baf9f78be70a91c2b8c7b3a3e8a4acce7813)