### PR TITLE
Revert "MULE-19992: Private object stores should be able to be expired in secondary node", further analysis required

### DIFF
--- a/src/main/java/org/mule/runtime/api/store/ObjectStoreSettings.java
+++ b/src/main/java/org/mule/runtime/api/store/ObjectStoreSettings.java
@@ -84,20 +84,6 @@ public class ObjectStoreSettings {
     }
 
     /**
-     * Sets whether the entries should always be expired when the expiration thread runs. It will only be used by the runtime if
-     * expiration is configured (i.e., {@link #entryTtl(Long)} or {@link #maxEntries(Integer)} were also invoked).
-     *
-     * @param alwaysExpire whether old entries should be expired every time the expiration thread runs
-     * @return {@code this} builder
-     *
-     * @since 1.3
-     */
-    public Builder alwaysExpire(boolean alwaysExpire) {
-      product.alwaysExpire = alwaysExpire;
-      return this;
-    }
-
-    /**
      * Returns the built settings object. {@code this} instance should be discarded and no longer used after invoking this method
      *
      * @return the built {@link ObjectStoreSettings} object
@@ -136,7 +122,6 @@ public class ObjectStoreSettings {
   private Integer maxEntries = null;
   private Long entryTTL;
   private long expirationInterval = DEFAULT_EXPIRATION_INTERVAL;
-  private boolean alwaysExpire = false;
 
   private ObjectStoreSettings() {}
 
@@ -169,14 +154,5 @@ public class ObjectStoreSettings {
    */
   public long getExpirationInterval() {
     return expirationInterval;
-  }
-
-  /**
-   * Whether old entries should be expired every time the expiration thread runs.
-   *
-   * @since 1.3
-   */
-  public boolean isAlwaysExpire() {
-    return alwaysExpire;
   }
 }


### PR DESCRIPTION
Reverts mulesoft/mule-api#919