### PR TITLE
EE-8118: Optimizations for the HTTP proxy path

### DIFF
--- a/src/main/java/org/mule/runtime/api/util/CaseInsensitiveMapWrapper.java
+++ b/src/main/java/org/mule/runtime/api/util/CaseInsensitiveMapWrapper.java
@@ -167,12 +167,14 @@ public class CaseInsensitiveMapWrapper<T> extends AbstractMap<String, T> impleme
 
       CaseInsensitiveMapKey value = cache.get(key);
       if (value == null) {
-        value = cache.computeIfAbsent(key, k -> new CaseInsensitiveMapKey(k));
-      }
+        value = cache.computeIfAbsent(key, CaseInsensitiveMapKey::new);
 
-      if (cache.size() > MAX_CACHE_SIZE) {
-        usingCache.set(false);
-        cache.clear();
+        // we do the size check only if the value was not present and needed to be computed
+        // being this a ConcurrentHashMap, getting the size is not as cheap as it looks
+        if (cache.size() > MAX_CACHE_SIZE) {
+          usingCache.set(false);
+          cache.clear();
+        }
       }
 
       return value;

--- a/src/main/java/org/mule/runtime/api/util/MultiMap.java
+++ b/src/main/java/org/mule/runtime/api/util/MultiMap.java
@@ -201,13 +201,14 @@ public class MultiMap<K, V> implements Map<K, V>, Serializable {
    * @param values collection of values to be associated with the specified key
    */
   public void put(K key, Collection<V> values) {
-    LinkedList<V> newValue = paramsMap.get(key);
-    if (newValue == null) {
-      newValue = new LinkedList<>(values);
-      paramsMap.put(key, newValue);
-    } else {
-      newValue.addAll(values);
-    }
+    paramsMap.compute(key, (k, curVal) -> {
+      if (curVal == null) {
+        return new LinkedList<>(values);
+      } else {
+        curVal.addAll(values);
+        return curVal;
+      }
+    });
   }
 
   @Override
@@ -252,10 +253,7 @@ public class MultiMap<K, V> implements Map<K, V>, Serializable {
    * @since 1.1.1
    */
   public void putAll(MultiMap<? extends K, ? extends V> aMultiMap) {
-    Set<? extends K> keySet = aMultiMap.keySet();
-    for (K key : keySet) {
-      put(key, (Collection<V>) aMultiMap.paramsMap.get(key));
-    }
+    aMultiMap.paramsMap.forEach((k, v) -> put(k, (Collection<V>) v));
   }
 
   @Override


### PR DESCRIPTION
* Optimizing keyFor by avoiding unnecessary calls for size computation on the ConcurrentHashMap.

* A few optimizations on MultiMap to avoid unnecessary hash computations.

(cherry picked from commit d2989f4d0a335d322c39a8427adbeb6895938440)