### PR TITLE
W-10998630: Remove warning: "An expression value was given for parame…

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -389,6 +389,15 @@
           "fieldName": "HONOUR_ERROR_MAPPINGS_WHEN_POLICY_APPLIED_ON_OPERATION_PROPERTY",
           "elementKind": "field",
           "justification": "W-11147961: Error Mapping not working while deploying Header Injection custom policy"
+        },
+        {
+          "code": "java.field.addedStaticField",
+          "new": "field org.mule.runtime.api.util.MuleSystemProperties.REVERT_SUPPORT_EXPRESSIONS_IN_VARIABLE_NAME_IN_SET_VARIABLE_PROPERTY",
+          "package": "org.mule.runtime.api.util",
+          "classSimpleName": "MuleSystemProperties",
+          "fieldName": "REVERT_SUPPORT_EXPRESSIONS_IN_VARIABLE_NAME_IN_SET_VARIABLE_PROPERTY",
+          "elementKind": "field",
+          "justification": "W-10998630: Remove warning: \"An expression value was given for parameter 'variableName' but it doesn't support expressions\" from logging"
         }
       ]
     }

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -383,6 +383,15 @@ public final class MuleSystemProperties {
       SYSTEM_PROPERTY_PREFIX + "reuse.globalErrorHandler";
 
   /**
+   * When set to true, the variableName identifier in SetVariable is set to not support expressions in the Mule Extension Model
+   * (W-10998630)
+   *
+   * @since 4.5.0, 4.4.0-202207, 4.3.0-202207
+   */
+  public static final String REVERT_SUPPORT_EXPRESSIONS_IN_VARIABLE_NAME_IN_SET_VARIABLE_PROPERTY =
+      SYSTEM_PROPERTY_PREFIX + "revertSupportExpressionsInVariableNameInSetVariable";
+
+  /**
    * @return {@code true} if the {@link #TESTING_MODE_PROPERTY_NAME} property has been set (regardless of the value)
    */
   public static boolean isTestingMode() {


### PR DESCRIPTION
…ter 'variableName' but it doesn't support expressions" from logging (#1010)

* Added fail safe

* W-10998630: Remove warning: "An expression value was given for parameter 'variableName' but it doesn't support expressions" from logging

* Changing property name

(cherry picked from commit 1d9eda54dfe07489ff039caa41ce59a4381825a2)