### PR TITLE
W-12181063: [Global Error Handling] remove the kill switch for enabling the memory fixes in 4.5 (#1089)

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -1,7 +1,31 @@
 {
+  "1.6.0": {
+    "revapi": {
+      "ignore": [
+        {
+          "code": "java.field.removedWithConstant",
+          "old": "field org.mule.runtime.api.util.MuleSystemProperties.REUSE_GLOBAL_ERROR_HANDLER_PROPERTY",
+          "package": "org.mule.runtime.api.util",
+          "classSimpleName": "MuleSystemProperties",
+          "fieldName": "REUSE_GLOBAL_ERROR_HANDLER_PROPERTY",
+          "elementKind": "field",
+          "justification": "W-12181063: [Global Error Handling] remove the kill switch for enabling the memory fixes in 4.5"
+        }
+      ]
+    }
+  },
   "1.5.0": {
     "revapi": {
       "ignore": [
+        {
+          "code": "java.field.removedWithConstant",
+          "old": "field org.mule.runtime.api.util.MuleSystemProperties.REUSE_GLOBAL_ERROR_HANDLER_PROPERTY",
+          "package": "org.mule.runtime.api.util",
+          "classSimpleName": "MuleSystemProperties",
+          "fieldName": "REUSE_GLOBAL_ERROR_HANDLER_PROPERTY",
+          "elementKind": "field",
+          "justification": "W-12181063: [Global Error Handling] remove the kill switch for enabling the memory fixes in 4.5"
+        },
         {
           "code": "java.method.defaultMethodAddedToInterface",
           "new": "method boolean org.mule.runtime.api.interception.ProcessorInterceptor::isErrorMappingRequired(org.mule.runtime.api.component.location.ComponentLocation)",

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -593,14 +593,6 @@ public final class MuleSystemProperties {
       SYSTEM_PROPERTY_PREFIX + "disableJDKVendorValidation";
 
   /**
-   * If set to true, the global error handlers will be reused instead of creating local copies.
-   *
-   * @since 4.5.0, 4.4.1, 4.3.1
-   */
-  public static final String REUSE_GLOBAL_ERROR_HANDLER_PROPERTY =
-      SYSTEM_PROPERTY_PREFIX + "reuse.globalErrorHandler";
-
-  /**
    * If set to true, {@link org.mule.runtime.api.notification.Notification}s related to polling sources will be emitted.
    *
    * @since 4.5.0


### PR DESCRIPTION
(cherry picked from commit be225153936c12964a2ca1d18014d0c6e7faf0e4)