### PR TITLE
W-12218381: [Global Error Handling] remove the system property reuse.globalErrorHandler in 4.3/4.4 and replace with a kill switch (#1091)

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -4,6 +4,15 @@
       "ignore": [
         {
           "code": "java.field.addedStaticField",
+          "new": "field org.mule.runtime.api.util.MuleSystemProperties.DISABLE_GLOBAL_ERROR_HANDLER_IMPROVEMENTS_PROPERTY",
+          "package": "org.mule.runtime.api.util",
+          "classSimpleName": "MuleSystemProperties",
+          "fieldName": "DISABLE_GLOBAL_ERROR_HANDLER_IMPROVEMENTS_PROPERTY",
+          "elementKind": "field",
+          "justification": "W-12218381: [Global Error Handling] remove the system property reuse.globalErrorHandler in 4.3/4.4 and replace with a kill switch"
+        },
+        {
+          "code": "java.field.addedStaticField",
           "new": "field org.mule.runtime.api.util.MuleSystemProperties.HONOUR_INSECURE_TLS_CONFIGURATION_PROPERTY",
           "package": "org.mule.runtime.api.util",
           "classSimpleName": "MuleSystemProperties",
@@ -446,7 +455,7 @@
         }
       ]
     }
-  }, 
+  },
   "1.3.0": {
     "revapi": {
       "ignore": [

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -399,7 +399,7 @@ public final class MuleSystemProperties {
    * @since 4.4.1, 4.3.1
    */
   public static final String DISABLE_GLOBAL_ERROR_HANDLER_IMPROVEMENTS_PROPERTY =
-    SYSTEM_PROPERTY_PREFIX + "disableGlobalErrorHandlerImprovements";
+      SYSTEM_PROPERTY_PREFIX + "disableGlobalErrorHandlerImprovements";
 
   /*
    * When set to true, transactions will be committed in case of redelivery exhausted error.

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -384,14 +384,6 @@ public final class MuleSystemProperties {
       SYSTEM_PROPERTY_PREFIX + "disableJDKVendorValidation";
 
   /**
-   * If set to true, the global error handlers will be reused instead of creating local copies.
-   *
-   * @since 4.5.0, 4.4.1, 4.3.1
-   */
-  public static final String REUSE_GLOBAL_ERROR_HANDLER_PROPERTY =
-      SYSTEM_PROPERTY_PREFIX + "reuse.globalErrorHandler";
-
-  /**
    * When set to true, the variableName identifier in SetVariable is set to not support expressions in the Mule Extension Model
    * (W-10998630)
    *

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -399,6 +399,16 @@ public final class MuleSystemProperties {
    */
   public static final String REVERT_SUPPORT_EXPRESSIONS_IN_VARIABLE_NAME_IN_SET_VARIABLE_PROPERTY =
       SYSTEM_PROPERTY_PREFIX + "revertSupportExpressionsInVariableNameInSetVariable";
+
+  /**
+   * If set to true, the global error handlers will create local copies instead of being reused. This is only for internal use in
+   * the runtime.
+   *
+   * @since 4.4.1, 4.3.1
+   */
+  public static final String DISABLE_GLOBAL_ERROR_HANDLER_IMPROVEMENTS_PROPERTY =
+    SYSTEM_PROPERTY_PREFIX + "disableGlobalErrorHandlerImprovements";
+
   /*
    * When set to true, transactions will be committed in case of redelivery exhausted error.
    * 


### PR DESCRIPTION
(cherry picked from commit 3d3ff201405247899206dbe9eb1b2efa3be45c7d)