### PR TITLE
Revert "W-12181063: [Global Error Handling] remove the kill switch fo…

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -1,31 +1,7 @@
 {
-  "1.6.0": {
-    "revapi": {
-      "ignore": [
-        {
-          "code": "java.field.removedWithConstant",
-          "old": "field org.mule.runtime.api.util.MuleSystemProperties.REUSE_GLOBAL_ERROR_HANDLER_PROPERTY",
-          "package": "org.mule.runtime.api.util",
-          "classSimpleName": "MuleSystemProperties",
-          "fieldName": "REUSE_GLOBAL_ERROR_HANDLER_PROPERTY",
-          "elementKind": "field",
-          "justification": "W-12181063: [Global Error Handling] remove the kill switch for enabling the memory fixes in 4.5"
-        }
-      ]
-    }
-  },
   "1.5.0": {
     "revapi": {
       "ignore": [
-        {
-          "code": "java.field.removedWithConstant",
-          "old": "field org.mule.runtime.api.util.MuleSystemProperties.REUSE_GLOBAL_ERROR_HANDLER_PROPERTY",
-          "package": "org.mule.runtime.api.util",
-          "classSimpleName": "MuleSystemProperties",
-          "fieldName": "REUSE_GLOBAL_ERROR_HANDLER_PROPERTY",
-          "elementKind": "field",
-          "justification": "W-12181063: [Global Error Handling] remove the kill switch for enabling the memory fixes in 4.5"
-        },
         {
           "code": "java.method.defaultMethodAddedToInterface",
           "new": "method boolean org.mule.runtime.api.interception.ProcessorInterceptor::isErrorMappingRequired(org.mule.runtime.api.component.location.ComponentLocation)",

--- a/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
+++ b/src/main/java/org/mule/runtime/api/util/MuleSystemProperties.java
@@ -593,6 +593,14 @@ public final class MuleSystemProperties {
       SYSTEM_PROPERTY_PREFIX + "disableJDKVendorValidation";
 
   /**
+   * If set to true, the global error handlers will be reused instead of creating local copies.
+   *
+   * @since 4.5.0, 4.4.1, 4.3.1
+   */
+  public static final String REUSE_GLOBAL_ERROR_HANDLER_PROPERTY =
+      SYSTEM_PROPERTY_PREFIX + "reuse.globalErrorHandler";
+
+  /**
    * If set to true, {@link org.mule.runtime.api.notification.Notification}s related to polling sources will be emitted.
    *
    * @since 4.5.0


### PR DESCRIPTION
…r enabling the memory fixes in 4.5 (#1089) (#1092)"

This reverts commit cfcb534ec4c02f78fe7ca12c7b526c78712cc021.

(cherry picked from commit 353fa80f7fa38679684726a588677356b65cb561)