### PR TITLE
W-13517980: Revapi validation must point to latest stable version, not a

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -252,13 +252,7 @@
           "fieldName": "DISABLE_REGISTRY_BOOTSTRAP_OPTIONAL_ENTRIES_PROPERTY",
           "elementKind": "field",
           "justification": "W-10825584: Fix system properry name and documentation"
-        }        
-      ]
-    }
-  },
-  "1.5.0": {
-    "revapi": {
-      "ignore": [
+        },
         {
           "code": "java.field.removedWithConstant",
           "old": "field org.mule.runtime.api.util.MuleSystemProperties.REUSE_GLOBAL_ERROR_HANDLER_PROPERTY",

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <allure.maven.plugin.version>2.9</allure.maven.plugin.version>
         <jacoco.version>0.8.8</jacoco.version>
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
-        <oldMuleArtifactVersion>1.5.0-SNAPSHOT</oldMuleArtifactVersion>
+        <oldMuleArtifactVersion>1.4.0</oldMuleArtifactVersion>
         <muleRevapiExtensionVersion>1.6.0-SNAPSHOT</muleRevapiExtensionVersion>
         <muleApiAnnotationsVersion>1.5.0-SNAPSHOT</muleApiAnnotationsVersion>
         <build.helper.maven.plugin.version>3.0.0</build.helper.maven.plugin.version>
@@ -566,7 +566,23 @@
                                               "patch" : "equivalent"
                                             }
                                           }
-                                        }
+                                        },
+                                        "ignore": [
+                                          {
+                                            "code": "java.annotation.removed",
+                                            "annotationType": "jdk.internal.HotSpotIntrinsicCandidate",
+                                            "annotation": "@jdk.internal.HotSpotIntrinsicCandidate",
+                                            "elementKind": "method",
+                                            "justification": "This annotation is in jdk class, this is a false positive."
+                                          },
+                                          {
+                                            "code": "java.annotation.removed",
+                                            "annotationType": "jdk.internal.vm.annotation.IntrinsicCandidate",
+                                            "annotation": "@jdk.internal.vm.annotation.IntrinsicCandidate",
+                                            "elementKind": "method",
+                                            "justification": "This annotation is in jdk class, this is a false positive."
+                                          }
+                                        ]
                                     }
                                 }
                             ]]>


### PR DESCRIPTION
snapshot