### PR TITLE
W-13465559: Fix revapi validation using as old version 1.4.0 because …

### DIFF
--- a/api-changes.json
+++ b/api-changes.json
@@ -3,6 +3,18 @@
     "revapi": {
       "ignore": [
         {
+          "code": "java.annotation.removed",
+          "old": "method int java.lang.Object::hashCode() @ org.mule.runtime.api.util.DataSize",
+          "new": "method int org.mule.runtime.api.util.DataSize::hashCode()",
+          "annotationType": "jdk.internal.vm.annotation.IntrinsicCandidate",
+          "annotation": "@jdk.internal.vm.annotation.IntrinsicCandidate",
+          "package": "org.mule.runtime.api.util",
+          "classSimpleName": "DataSize",
+          "methodName": "hashCode",
+          "elementKind": "method",
+          "justification": "<TO COMPLETE>"
+        },
+        {
           "code": "java.class.nonFinalClassInheritsFromNewClass",
           "old": "class org.mule.runtime.api.meta.model.declaration.fluent.ComponentDeclaration<T extends org.mule.runtime.api.meta.model.declaration.fluent.ComponentDeclaration>",
           "new": "class org.mule.runtime.api.meta.model.declaration.fluent.ComponentDeclaration<T extends org.mule.runtime.api.meta.model.declaration.fluent.ComponentDeclaration>",
@@ -252,13 +264,7 @@
           "fieldName": "DISABLE_REGISTRY_BOOTSTRAP_OPTIONAL_ENTRIES_PROPERTY",
           "elementKind": "field",
           "justification": "W-10825584: Fix system properry name and documentation"
-        }        
-      ]
-    }
-  },
-  "1.5.0": {
-    "revapi": {
-      "ignore": [
+        },
         {
           "code": "java.field.removedWithConstant",
           "old": "field org.mule.runtime.api.util.MuleSystemProperties.REUSE_GLOBAL_ERROR_HANDLER_PROPERTY",

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <allure.maven.plugin.version>2.9</allure.maven.plugin.version>
         <jacoco.version>0.8.8</jacoco.version>
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
-        <oldMuleArtifactVersion>1.5.0-SNAPSHOT</oldMuleArtifactVersion>
+        <oldMuleArtifactVersion>1.4.0</oldMuleArtifactVersion>
         <muleRevapiExtensionVersion>1.6.0-SNAPSHOT</muleRevapiExtensionVersion>
         <muleApiAnnotationsVersion>1.5.0-SNAPSHOT</muleApiAnnotationsVersion>
         <build.helper.maven.plugin.version>3.0.0</build.helper.maven.plugin.version>


### PR DESCRIPTION
…we are going to replace 4.5.0-SNAPSHOT with the main branches