### PR TITLE
W-14678431: Use the MetadataType cache again, and separate the constant types in a separate map

### DIFF
--- a/src/main/java/org/mule/runtime/api/metadata/MediaType.java
+++ b/src/main/java/org/mule/runtime/api/metadata/MediaType.java
@@ -84,6 +84,7 @@ public final class MediaType implements Serializable {
   private static Map<String, MediaType> predefined;
 
   static {
+    // Create a set of predefined (constant) types, so that we don't have to create them when someone calls parse().
     predefined = new HashMap<>(16);
 
     ANY = createConstant("*", "*");
@@ -130,7 +131,7 @@ public final class MediaType implements Serializable {
    * @return {@link MediaType} instance for the parsed {@code mediaType} string.
    */
   public static MediaType parse(String mediaType) {
-    return getCached(mediaType).orElseGet(() -> parseMediaType(mediaType, false));
+    return getKnown(mediaType).orElseGet(() -> parseMediaType(mediaType, false));
   }
 
   /**
@@ -145,18 +146,23 @@ public final class MediaType implements Serializable {
    * @since 1.4, 1.3.1, 1.2.4, 1.1.7
    */
   public static MediaType parseDefinedInApp(String mediaType) {
-    return getCached(mediaType).orElseGet(() -> parseMediaType(mediaType, true));
+    return getKnown(mediaType).orElseGet(() -> parseMediaType(mediaType, true));
   }
 
-  private static Optional<MediaType> getCached(String mediaType) {
+  private static Optional<MediaType> getKnown(String mediaType) {
+    // Check if it's one of the constant types
     MediaType predefinedFound = predefined.get(mediaType);
     if (predefinedFound != null) {
       return of(predefinedFound);
     }
+
+    // Check if we already parsed this type
     MediaType cachedFound = cache.getIfPresent(mediaType);
     if (cachedFound != null) {
       return of(cachedFound);
     }
+
+    // We don't have this type memorized
     return empty();
   }
 

--- a/src/main/java/org/mule/runtime/api/metadata/MediaType.java
+++ b/src/main/java/org/mule/runtime/api/metadata/MediaType.java
@@ -105,9 +105,11 @@ public final class MediaType implements Serializable {
    * @return {@link MediaType} instance for the parsed {@code mediaType} string.
    */
   public static MediaType parse(String mediaType) {
-    MediaType cachedMediaType = parseMediaType(mediaType, false);
-
-    return cachedMediaType;
+    MediaType cachedMediaType = cache.getIfPresent(mediaType);
+    if (cachedMediaType != null) {
+      return cachedMediaType;
+    }
+    return parseMediaType(mediaType, false);
   }
 
   /**
@@ -122,9 +124,11 @@ public final class MediaType implements Serializable {
    * @since 1.4, 1.3.1, 1.2.4, 1.1.7
    */
   public static MediaType parseDefinedInApp(String mediaType) {
-    MediaType cachedMediaType = parseMediaType(mediaType, true);
-
-    return cachedMediaType;
+    MediaType cachedMediaType = cache.getIfPresent(mediaType);
+    if (cachedMediaType != null) {
+      return cachedMediaType;
+    }
+    return parseMediaType(mediaType, true);
   }
 
   private static MediaType parseMediaType(String mediaType, boolean definedInApp) {

--- a/src/test/java/org/mule/runtime/api/test/metadata/MediaTypeTestCase.java
+++ b/src/test/java/org/mule/runtime/api/test/metadata/MediaTypeTestCase.java
@@ -345,6 +345,28 @@ public class MediaTypeTestCase {
   }
 
   @Test
+  public void constantsAndParsedSameInstance() {
+    final MediaType appXml = APPLICATION_XML;
+    assertThat(MediaType.parse(appXml.toRfcString()), sameInstance(appXml));
+  }
+
+  @Test
+  public void sameParsedWithParamsNotSameInstance() {
+    final MediaType withParam1 = MediaType.parse("multipart/lalala; boundary=\"---- next message ----\"");
+    final MediaType withParam2 = MediaType.parse("multipart/lalala; boundary=\"---- next message ----\"");
+
+    assertThat(withParam1, not(sameInstance(withParam2)));
+  }
+
+  @Test
+  public void withoutParametersCached() {
+    final MediaType withParam = MediaType.parse("multipart/lalala; boundary=\"---- next message ----\"");
+    final MediaType withoutParam = MediaType.parse("multipart/lalala");
+
+    assertThat(withParam.withoutParameters(), sameInstance(withoutParam));
+  }
+
+  @Test
   @Issue("W-14490182")
   public void avoidDoSUsingMimeTypeCaching() {
     for (int i = 0; i < 100; i++) {
@@ -352,5 +374,4 @@ public class MediaTypeTestCase {
     }
     assertThat(MediaType.getCacheSize(), is(32));
   }
-
 }

--- a/src/test/java/org/mule/runtime/api/test/metadata/MediaTypeTestCase.java
+++ b/src/test/java/org/mule/runtime/api/test/metadata/MediaTypeTestCase.java
@@ -345,12 +345,14 @@ public class MediaTypeTestCase {
   }
 
   @Test
+  @Issue("W-14678431")
   public void constantsAndParsedSameInstance() {
     final MediaType appXml = APPLICATION_XML;
     assertThat(MediaType.parse(appXml.toRfcString()), sameInstance(appXml));
   }
 
   @Test
+  @Issue("W-14678431")
   public void sameParsedWithParamsNotSameInstance() {
     final MediaType withParam1 = MediaType.parse("multipart/lalala; boundary=\"---- next message ----\"");
     final MediaType withParam2 = MediaType.parse("multipart/lalala; boundary=\"---- next message ----\"");
@@ -359,6 +361,7 @@ public class MediaTypeTestCase {
   }
 
   @Test
+  @Issue("W-14678431")
   public void withoutParametersCached() {
     final MediaType withParam = MediaType.parse("multipart/lalala; boundary=\"---- next message ----\"");
     final MediaType withoutParam = MediaType.parse("multipart/lalala");


### PR DESCRIPTION
The cache usage was removed accidentally in 3427625. This caused a degradation in some of our benchmarks. We're restoring the cache usage.
Apart of that, to avoid re-calculating the constant MetadataType values, we're removing them from the cache and introducing a new map of predefined types.
We have tested 4.6.0-rc2 vs 4.6.0-rc3 vs a custom runtime with 4.6.0-rc3 plus this change. Here is a graphic showing the degradation and the improvement:
<img width="954" alt="Screenshot 2024-02-06 at 14 35 54" src="https://github.com/mulesoft/mule-api/assets/14245286/4110a94b-42aa-43ad-970a-e555afc714eb">
