### PR TITLE
W-14678431: Use the MetadataType cache again, and separate the constant types in a separate map (#1286)

### DIFF
--- a/src/main/java/org/mule/runtime/api/metadata/MediaType.java
+++ b/src/main/java/org/mule/runtime/api/metadata/MediaType.java
@@ -13,6 +13,9 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.list;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 
 import static com.github.benmanes.caffeine.cache.Caffeine.newBuilder;
@@ -62,24 +65,47 @@ public final class MediaType implements Serializable {
   private static final Cache<String, MediaType> cache = newBuilder().maximumSize(32).build();
 
 
-  public static final MediaType ANY = create("*", "*");
+  public static final MediaType ANY;
+  public static final MediaType JSON;
+  public static final MediaType APPLICATION_JSON;
+  public static final MediaType APPLICATION_JAVA;
+  public static final MediaType ATOM;
+  public static final MediaType RSS;
+  public static final MediaType APPLICATION_XML;
+  public static final MediaType XML;
+  public static final MediaType TEXT;
+  public static final MediaType HTML;
+  public static final MediaType BINARY;
+  public static final MediaType UNKNOWN;
+  public static final MediaType MULTIPART_MIXED;
+  public static final MediaType MULTIPART_FORM_DATA;
+  public static final MediaType MULTIPART_RELATED;
+  public static final MediaType MULTIPART_X_MIXED_REPLACE;
+  private static Map<String, MediaType> predefined;
 
-  public static final MediaType JSON = create(TYPE_TEXT, SUBTYPE_JSON);
-  public static final MediaType APPLICATION_JSON = create(TYPE_APPLICATION, SUBTYPE_JSON);
-  public static final MediaType APPLICATION_JAVA = create(TYPE_APPLICATION, "java");
-  public static final MediaType ATOM = create(TYPE_APPLICATION, "atom+" + SUBTYPE_XML);
-  public static final MediaType RSS = create(TYPE_APPLICATION, "rss+" + SUBTYPE_XML);
-  public static final MediaType APPLICATION_XML = create(TYPE_APPLICATION, SUBTYPE_XML);
-  public static final MediaType XML = create(TYPE_TEXT, SUBTYPE_XML);
-  public static final MediaType TEXT = create(TYPE_TEXT, SUBTYPE_PLAIN);
-  public static final MediaType HTML = create(TYPE_TEXT, SUBTYPE_HTML);
+  static {
+    // Create a set of predefined (constant) types, so that we don't have to create them when someone calls parse().
+    predefined = new HashMap<>(16);
 
-  public static final MediaType BINARY = create(TYPE_APPLICATION, SUBTYPE_OCTET_STREAM);
-  public static final MediaType UNKNOWN = create("content", "unknown");
-  public static final MediaType MULTIPART_MIXED = create(TYPE_MULTIPART, SUBTYPE_MIXED);
-  public static final MediaType MULTIPART_FORM_DATA = create(TYPE_MULTIPART, SUBTYPE_FORM_DATA);
-  public static final MediaType MULTIPART_RELATED = create(TYPE_MULTIPART, SUBTYPE_RELATED);
-  public static final MediaType MULTIPART_X_MIXED_REPLACE = create(TYPE_MULTIPART, "x-" + SUBTYPE_MIXED + "-replace");
+    ANY = createConstant("*", "*");
+    JSON = createConstant(TYPE_TEXT, SUBTYPE_JSON);
+    APPLICATION_JSON = createConstant(TYPE_APPLICATION, SUBTYPE_JSON);
+    APPLICATION_JAVA = createConstant(TYPE_APPLICATION, "java");
+    ATOM = createConstant(TYPE_APPLICATION, "atom+" + SUBTYPE_XML);
+    RSS = createConstant(TYPE_APPLICATION, "rss+" + SUBTYPE_XML);
+    APPLICATION_XML = createConstant(TYPE_APPLICATION, SUBTYPE_XML);
+    XML = createConstant(TYPE_TEXT, SUBTYPE_XML);
+    TEXT = createConstant(TYPE_TEXT, SUBTYPE_PLAIN);
+    HTML = createConstant(TYPE_TEXT, SUBTYPE_HTML);
+    BINARY = createConstant(TYPE_APPLICATION, SUBTYPE_OCTET_STREAM);
+    UNKNOWN = createConstant("content", "unknown");
+    MULTIPART_MIXED = createConstant(TYPE_MULTIPART, SUBTYPE_MIXED);
+    MULTIPART_FORM_DATA = createConstant(TYPE_MULTIPART, SUBTYPE_FORM_DATA);
+    MULTIPART_RELATED = createConstant(TYPE_MULTIPART, SUBTYPE_RELATED);
+    MULTIPART_X_MIXED_REPLACE = createConstant(TYPE_MULTIPART, "x-" + SUBTYPE_MIXED + "-replace");
+
+    predefined = unmodifiableMap(predefined);
+  }
 
   private static List<String> KNOWN_PARAM_NAMES =
       getProperty(MULE_KNOWN_MEDIA_TYPE_PARAM_NAMES) != null
@@ -105,9 +131,7 @@ public final class MediaType implements Serializable {
    * @return {@link MediaType} instance for the parsed {@code mediaType} string.
    */
   public static MediaType parse(String mediaType) {
-    MediaType cachedMediaType = parseMediaType(mediaType, false);
-
-    return cachedMediaType;
+    return getKnown(mediaType).orElseGet(() -> parseMediaType(mediaType, false));
   }
 
   /**
@@ -122,9 +146,24 @@ public final class MediaType implements Serializable {
    * @since 1.4, 1.3.1, 1.2.4, 1.1.7
    */
   public static MediaType parseDefinedInApp(String mediaType) {
-    MediaType cachedMediaType = parseMediaType(mediaType, true);
+    return getKnown(mediaType).orElseGet(() -> parseMediaType(mediaType, true));
+  }
 
-    return cachedMediaType;
+  private static Optional<MediaType> getKnown(String mediaType) {
+    // Check if it's one of the constant types
+    MediaType predefinedFound = predefined.get(mediaType);
+    if (predefinedFound != null) {
+      return of(predefinedFound);
+    }
+
+    // Check if we already parsed this type
+    MediaType cachedFound = cache.getIfPresent(mediaType);
+    if (cachedFound != null) {
+      return of(cachedFound);
+    }
+
+    // We don't have this type memorized
+    return empty();
   }
 
   private static MediaType parseMediaType(String mediaType, boolean definedInApp) {
@@ -185,6 +224,12 @@ public final class MediaType implements Serializable {
    */
   public static MediaType create(String primaryType, String subType) {
     return create(primaryType, subType, null);
+  }
+
+  private static MediaType createConstant(String primaryType, String subType) {
+    final MediaType value = new MediaType(primaryType, subType, emptyMap(), null, true);
+    predefined.put(value.toRfcString(), value);
+    return value;
   }
 
   /**

--- a/src/test/java/org/mule/runtime/api/test/metadata/MediaTypeTestCase.java
+++ b/src/test/java/org/mule/runtime/api/test/metadata/MediaTypeTestCase.java
@@ -345,6 +345,31 @@ public class MediaTypeTestCase {
   }
 
   @Test
+  @Issue("W-14678431")
+  public void constantsAndParsedSameInstance() {
+    final MediaType appXml = APPLICATION_XML;
+    assertThat(MediaType.parse(appXml.toRfcString()), sameInstance(appXml));
+  }
+
+  @Test
+  @Issue("W-14678431")
+  public void sameParsedWithParamsNotSameInstance() {
+    final MediaType withParam1 = MediaType.parse("multipart/lalala; boundary=\"---- next message ----\"");
+    final MediaType withParam2 = MediaType.parse("multipart/lalala; boundary=\"---- next message ----\"");
+
+    assertThat(withParam1, not(sameInstance(withParam2)));
+  }
+
+  @Test
+  @Issue("W-14678431")
+  public void withoutParametersCached() {
+    final MediaType withParam = MediaType.parse("multipart/lalala; boundary=\"---- next message ----\"");
+    final MediaType withoutParam = MediaType.parse("multipart/lalala");
+
+    assertThat(withParam.withoutParameters(), sameInstance(withoutParam));
+  }
+
+  @Test
   @Issue("W-14490182")
   public void avoidDoSUsingMimeTypeCaching() {
     for (int i = 0; i < 100; i++) {
@@ -352,5 +377,4 @@ public class MediaTypeTestCase {
     }
     assertThat(MediaType.getCacheSize(), is(32));
   }
-
 }


### PR DESCRIPTION
(cherry picked from commit ddf5538d77faba4c7f1b6ebc3f7f44ec592b3f4c)