### PR TITLE
W-15194030: use thread's context class loader for SPI lookup

### DIFF
--- a/src/main/java/org/mule/runtime/api/el/AbstractBindingContextBuilderFactory.java
+++ b/src/main/java/org/mule/runtime/api/el/AbstractBindingContextBuilderFactory.java
@@ -33,12 +33,12 @@ public abstract class AbstractBindingContextBuilderFactory {
       try {
         final AbstractBindingContextBuilderFactory factory =
             load(AbstractBindingContextBuilderFactory.class, classLoader).iterator().next();
-        LOGGER.info(format("Loaded MuleMessageBuilderFactory implementation '%s' from classloader '%s'",
+        LOGGER.info(format("Loaded BindingContextBuilderFactory implementation '%s' from classloader '%s'",
                            factory.getClass().getName(), factory.getClass().getClassLoader().toString()));
 
         DEFAULT_FACTORY = factory;
       } catch (Throwable t) {
-        LOGGER.error("Error loading MuleMessageBuilderFactory implementation.", t);
+        LOGGER.error("Error loading BindingContextBuilderFactory implementation.", t);
         throw t;
       }
     }
@@ -64,8 +64,7 @@ public abstract class AbstractBindingContextBuilderFactory {
       try {
         classLoader = currentThread().getContextClassLoader().loadClass("org.mule.runtime.core.api.MuleContext").getClassLoader();
       } catch (ClassNotFoundException e) {
-        throw new MuleRuntimeException(createStaticMessage(format("Failed obtaining class loader to load %s",
-                                                                  AbstractBindingContextBuilderFactory.class.getName())),
+        throw new MuleRuntimeException(createStaticMessage("Failed obtaining class loader to load BindingContextBuilderFactory implementation"),
                                        e);
       }
 

--- a/src/main/java/org/mule/runtime/api/el/AbstractBindingContextBuilderFactory.java
+++ b/src/main/java/org/mule/runtime/api/el/AbstractBindingContextBuilderFactory.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.api.el;
 
 import static java.lang.String.format;
+import static java.lang.Thread.currentThread;
 import static java.util.ServiceLoader.load;
 
 import org.mule.api.annotation.NoImplement;
@@ -27,7 +28,7 @@ public abstract class AbstractBindingContextBuilderFactory {
   static {
     try {
       final AbstractBindingContextBuilderFactory factory = load(AbstractBindingContextBuilderFactory.class,
-                                                                AbstractBindingContextBuilderFactory.class.getClassLoader())
+                                                                currentThread().getContextClassLoader())
                                                                     .iterator().next();
       LOGGER.info(format("Loaded BindingContextBuilderFactory implementation '%s' from classloader '%s'",
                          factory.getClass().getName(), factory.getClass().getClassLoader().toString()));

--- a/src/main/java/org/mule/runtime/api/el/AbstractExpressionModuleBuilderFactory.java
+++ b/src/main/java/org/mule/runtime/api/el/AbstractExpressionModuleBuilderFactory.java
@@ -6,10 +6,14 @@
  */
 package org.mule.runtime.api.el;
 
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+
 import static java.lang.String.format;
+import static java.lang.Thread.currentThread;
 import static java.util.ServiceLoader.load;
 
 import org.mule.api.annotation.NoImplement;
+import org.mule.runtime.api.exception.MuleRuntimeException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,25 +28,28 @@ public abstract class AbstractExpressionModuleBuilderFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractExpressionModuleBuilderFactory.class);
 
-  static {
-    try {
-      final AbstractExpressionModuleBuilderFactory factory = load(AbstractExpressionModuleBuilderFactory.class).iterator().next();
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug(format("Loaded ExpressionModuleBuilderFactory implementation '%s' from classloader '%s'",
-                            factory.getClass().getName(), factory.getClass().getClassLoader().toString()));
-      }
+  private static AbstractExpressionModuleBuilderFactory loadFactory(ClassLoader classLoader) {
+    if (DEFAULT_FACTORY == null) {
+      try {
+        final AbstractExpressionModuleBuilderFactory factory =
+            load(AbstractExpressionModuleBuilderFactory.class, classLoader).iterator().next();
+        LOGGER.info(format("Loaded MuleMessageBuilderFactory implementation '%s' from classloader '%s'",
+                           factory.getClass().getName(), factory.getClass().getClassLoader().toString()));
 
-      DEFAULT_FACTORY = factory;
-    } catch (Throwable t) {
-      LOGGER.error("Error loading ExpressionModuleBuilderFactory implementation.", t);
-      throw t;
+        DEFAULT_FACTORY = factory;
+      } catch (Throwable t) {
+        LOGGER.error("Error loading MuleMessageBuilderFactory implementation.", t);
+        throw t;
+      }
     }
+
+    return DEFAULT_FACTORY;
   }
 
-  private static final AbstractExpressionModuleBuilderFactory DEFAULT_FACTORY;
+  private static AbstractExpressionModuleBuilderFactory DEFAULT_FACTORY;
 
   /**
-   * The implementation of this abstract class is provided by the Mule Runtime, and loaded during this class initialization.
+   * The implementation of this abstract class is provided by the Mule Runtime.
    * <p>
    * If more than one implementation is found, the classLoading order of those implementations will determine which one is used.
    * Information about this will be logged to aid in the troubleshooting of those cases.
@@ -50,7 +57,35 @@ public abstract class AbstractExpressionModuleBuilderFactory {
    * @return the implementation of this builder factory provided by the Mule Runtime.
    */
   static AbstractExpressionModuleBuilderFactory getDefaultFactory() {
-    return DEFAULT_FACTORY;
+    try {
+      return getDefaultFactory(currentThread().getContextClassLoader());
+    } catch (Throwable t) {
+      ClassLoader classLoader;
+      try {
+        classLoader = currentThread().getContextClassLoader().loadClass("org.mule.runtime.core.api.MuleContext").getClassLoader();
+      } catch (ClassNotFoundException e) {
+        throw new MuleRuntimeException(createStaticMessage(format("Failed obtaining class loader to load %s",
+                                                                  AbstractExpressionModuleBuilderFactory.class.getName())),
+                                       e);
+      }
+
+      return getDefaultFactory(classLoader);
+    }
+  }
+
+  /**
+   * The implementation of this abstract class is provided by the Mule Runtime.
+   * <p>
+   * If more than one implementation is found, the classLoading order of those implementations will determine which one is used.
+   * Information about this will be logged to aid in the troubleshooting of those cases.
+   * <p>
+   * <b>NOTE</b>: this method is for internal use only.
+   *
+   * @param classLoader the class loader where the implementation will be looked up.
+   * @return the implementation of this builder factory provided by the Mule Runtime.
+   */
+  static AbstractExpressionModuleBuilderFactory getDefaultFactory(ClassLoader classLoader) {
+    return loadFactory(classLoader);
   }
 
   /**

--- a/src/main/java/org/mule/runtime/api/el/AbstractExpressionModuleBuilderFactory.java
+++ b/src/main/java/org/mule/runtime/api/el/AbstractExpressionModuleBuilderFactory.java
@@ -33,12 +33,12 @@ public abstract class AbstractExpressionModuleBuilderFactory {
       try {
         final AbstractExpressionModuleBuilderFactory factory =
             load(AbstractExpressionModuleBuilderFactory.class, classLoader).iterator().next();
-        LOGGER.info(format("Loaded MuleMessageBuilderFactory implementation '%s' from classloader '%s'",
+        LOGGER.info(format("Loaded ExpressionModuleBuilderFactory implementation '%s' from classloader '%s'",
                            factory.getClass().getName(), factory.getClass().getClassLoader().toString()));
 
         DEFAULT_FACTORY = factory;
       } catch (Throwable t) {
-        LOGGER.error("Error loading MuleMessageBuilderFactory implementation.", t);
+        LOGGER.error("Error loading ExpressionModuleBuilderFactory implementation.", t);
         throw t;
       }
     }
@@ -64,8 +64,7 @@ public abstract class AbstractExpressionModuleBuilderFactory {
       try {
         classLoader = currentThread().getContextClassLoader().loadClass("org.mule.runtime.core.api.MuleContext").getClassLoader();
       } catch (ClassNotFoundException e) {
-        throw new MuleRuntimeException(createStaticMessage(format("Failed obtaining class loader to load %s",
-                                                                  AbstractExpressionModuleBuilderFactory.class.getName())),
+        throw new MuleRuntimeException(createStaticMessage("Failed obtaining class loader to load ExpressionModuleBuilderFactory implementation"),
                                        e);
       }
 

--- a/src/main/java/org/mule/runtime/api/message/AbstractMuleMessageBuilderFactory.java
+++ b/src/main/java/org/mule/runtime/api/message/AbstractMuleMessageBuilderFactory.java
@@ -63,8 +63,7 @@ public abstract class AbstractMuleMessageBuilderFactory {
       try {
         classLoader = currentThread().getContextClassLoader().loadClass("org.mule.runtime.core.api.MuleContext").getClassLoader();
       } catch (ClassNotFoundException e) {
-        throw new MuleRuntimeException(createStaticMessage(format("Failed obtaining class loader to load %s",
-                                                                  AbstractMuleMessageBuilderFactory.class.getName())),
+        throw new MuleRuntimeException(createStaticMessage("Failed obtaining class loader to load MuleMessageBuilderFactory implementation"),
                                        e);
       }
 

--- a/src/main/java/org/mule/runtime/api/message/AbstractMuleMessageBuilderFactory.java
+++ b/src/main/java/org/mule/runtime/api/message/AbstractMuleMessageBuilderFactory.java
@@ -15,6 +15,9 @@ import static java.util.ServiceLoader.load;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.message.Message.Builder;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,24 +31,20 @@ public abstract class AbstractMuleMessageBuilderFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMuleMessageBuilderFactory.class);
 
   private static AbstractMuleMessageBuilderFactory loadFactory(ClassLoader classLoader) {
-    if (DEFAULT_FACTORY == null) {
-      try {
-        final AbstractMuleMessageBuilderFactory factory =
-            load(AbstractMuleMessageBuilderFactory.class, classLoader).iterator().next();
-        LOGGER.info(format("Loaded MuleMessageBuilderFactory implementation '%s' from classloader '%s'",
-                           factory.getClass().getName(), factory.getClass().getClassLoader().toString()));
+    try {
+      final AbstractMuleMessageBuilderFactory factory =
+          load(AbstractMuleMessageBuilderFactory.class, classLoader).iterator().next();
+      LOGGER.info(format("Loaded MuleMessageBuilderFactory implementation '%s' from classloader '%s'",
+                         factory.getClass().getName(), factory.getClass().getClassLoader().toString()));
 
-        DEFAULT_FACTORY = factory;
-      } catch (Throwable t) {
-        LOGGER.error("Error loading MuleMessageBuilderFactory implementation.", t);
-        throw t;
-      }
+      return factory;
+    } catch (Throwable t) {
+      LOGGER.error("Error loading MuleMessageBuilderFactory implementation.", t);
+      throw t;
     }
-
-    return DEFAULT_FACTORY;
   }
 
-  private static AbstractMuleMessageBuilderFactory DEFAULT_FACTORY;
+  private static final Map<ClassLoader, AbstractMuleMessageBuilderFactory> factoriesMap = new HashMap<>();
 
   /**
    * The implementation of this abstract class is provided by the Mule Runtime.
@@ -56,34 +55,35 @@ public abstract class AbstractMuleMessageBuilderFactory {
    * @return the implementation of this builder factory provided by the Mule Runtime.
    */
   static AbstractMuleMessageBuilderFactory getDefaultFactory() {
+    ClassLoader contextClassLoader = currentThread().getContextClassLoader();
     try {
-      return getDefaultFactory(currentThread().getContextClassLoader());
+      return getDefaultFactory(contextClassLoader);
     } catch (Throwable t) {
       ClassLoader classLoader;
       try {
-        classLoader = currentThread().getContextClassLoader().loadClass("org.mule.runtime.core.api.MuleContext").getClassLoader();
+        classLoader = contextClassLoader.loadClass("org.mule.runtime.core.api.MuleContext").getClassLoader();
       } catch (ClassNotFoundException e) {
         throw new MuleRuntimeException(createStaticMessage("Failed obtaining class loader to load MuleMessageBuilderFactory implementation"),
                                        e);
       }
 
-      return getDefaultFactory(classLoader);
+      AbstractMuleMessageBuilderFactory defaultFactory = null;
+      try {
+        defaultFactory = getDefaultFactory(classLoader);
+      } finally {
+        // Next time this thread's context class loader is used to retrieve the factory, we return it instead of computing it
+        // again
+        if (defaultFactory != null) {
+          factoriesMap.put(contextClassLoader, defaultFactory);
+        }
+      }
+
+      return defaultFactory;
     }
   }
 
-  /**
-   * The implementation of this abstract class is provided by the Mule Runtime.
-   * <p>
-   * If more than one implementation is found, the classLoading order of those implementations will determine which one is used.
-   * Information about this will be logged to aid in the troubleshooting of those cases.
-   * <p>
-   * <b>NOTE</b>: this method is for internal use only.
-   *
-   * @param classLoader the class loader where the implementation will be looked up.
-   * @return the implementation of this builder factory provided by the Mule Runtime.
-   */
-  static AbstractMuleMessageBuilderFactory getDefaultFactory(ClassLoader classLoader) {
-    return loadFactory(classLoader);
+  private static AbstractMuleMessageBuilderFactory getDefaultFactory(ClassLoader classLoader) {
+    return factoriesMap.computeIfAbsent(classLoader, AbstractMuleMessageBuilderFactory::loadFactory);
   }
 
   /**

--- a/src/main/java/org/mule/runtime/api/message/AbstractMuleMessageBuilderFactory.java
+++ b/src/main/java/org/mule/runtime/api/message/AbstractMuleMessageBuilderFactory.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.api.message;
 
 import static java.lang.String.format;
+import static java.lang.Thread.currentThread;
 import static java.util.ServiceLoader.load;
 import org.mule.runtime.api.message.Message.Builder;
 
@@ -25,8 +26,8 @@ public abstract class AbstractMuleMessageBuilderFactory {
   static {
     try {
       final AbstractMuleMessageBuilderFactory factory = load(AbstractMuleMessageBuilderFactory.class,
-                                                             AbstractMuleMessageBuilderFactory.class.getClassLoader()).iterator()
-                                                                 .next();
+                                                             currentThread().getContextClassLoader())
+                                                                 .iterator().next();
       LOGGER.info(format("Loaded MuleMessageBuilderFactory implementation '%s' from classloader '%s'",
                          factory.getClass().getName(), factory.getClass().getClassLoader().toString()));
 

--- a/src/main/java/org/mule/runtime/api/message/Message.java
+++ b/src/main/java/org/mule/runtime/api/message/Message.java
@@ -47,6 +47,31 @@ public interface Message extends Serializable {
   }
 
   /**
+   * Provides a builder to create {@link Message} objects.
+   * <p>
+   * <b>NOTE</b>: this method is for internal use only.
+   *
+   * @param classLoader the class loader where the builder implementation will be looked up.
+   * @return a new {@link Builder}.
+   */
+  static PayloadBuilder builder(ClassLoader classLoader) {
+    return AbstractMuleMessageBuilderFactory.getDefaultFactory(classLoader).create();
+  }
+
+  /**
+   * Provides a builder to create {@link Message} objects based on an existing {@link Message} instance.
+   * <p>
+   * <b>NOTE</b>: this method is for internal use only.
+   *
+   * @param message     existing {@link Message} to use as a template to create a new {@link Builder} instance.
+   * @param classLoader the class loader where the builder implementation will be looked up.
+   * @return a new {@link Builder} based on the template {@code message} provided.
+   */
+  static Builder builder(Message message, ClassLoader classLoader) {
+    return AbstractMuleMessageBuilderFactory.getDefaultFactory(classLoader).create(message);
+  }
+
+  /**
    * Gets a {@link TypedValue} with the payload of this message.
    *
    * @param <T> the type of the payload.
@@ -75,6 +100,20 @@ public interface Message extends Serializable {
    */
   static Message of(Object payload) {
     return builder().value(payload).build();
+  }
+
+  /**
+   * Create a new {@link Message instance} with the given payload.
+   * <p>
+   * <b>NOTE</b>: this method is for internal use only.
+   *
+   * @param classLoader the class loader where the builder implementation will be looked up.
+   *
+   * @param payload     the message payload
+   * @return new message instance
+   */
+  static Message of(Object payload, ClassLoader classLoader) {
+    return builder(classLoader).value(payload).build();
   }
 
   /**

--- a/src/main/java/org/mule/runtime/api/message/Message.java
+++ b/src/main/java/org/mule/runtime/api/message/Message.java
@@ -55,7 +55,8 @@ public interface Message extends Serializable {
    * @return a new {@link Builder}.
    */
   static PayloadBuilder builder(ClassLoader classLoader) {
-    return AbstractMuleMessageBuilderFactory.getDefaultFactory(classLoader).create();
+    // TODO: remove after test if successful
+    return AbstractMuleMessageBuilderFactory.getDefaultFactory().create();
   }
 
   /**
@@ -68,7 +69,8 @@ public interface Message extends Serializable {
    * @return a new {@link Builder} based on the template {@code message} provided.
    */
   static Builder builder(Message message, ClassLoader classLoader) {
-    return AbstractMuleMessageBuilderFactory.getDefaultFactory(classLoader).create(message);
+    // TODO: remove after test if successful
+    return AbstractMuleMessageBuilderFactory.getDefaultFactory().create(message);
   }
 
   /**

--- a/src/main/java/org/mule/runtime/api/message/Message.java
+++ b/src/main/java/org/mule/runtime/api/message/Message.java
@@ -47,33 +47,6 @@ public interface Message extends Serializable {
   }
 
   /**
-   * Provides a builder to create {@link Message} objects.
-   * <p>
-   * <b>NOTE</b>: this method is for internal use only.
-   *
-   * @param classLoader the class loader where the builder implementation will be looked up.
-   * @return a new {@link Builder}.
-   */
-  static PayloadBuilder builder(ClassLoader classLoader) {
-    // TODO: remove after test if successful
-    return AbstractMuleMessageBuilderFactory.getDefaultFactory().create();
-  }
-
-  /**
-   * Provides a builder to create {@link Message} objects based on an existing {@link Message} instance.
-   * <p>
-   * <b>NOTE</b>: this method is for internal use only.
-   *
-   * @param message     existing {@link Message} to use as a template to create a new {@link Builder} instance.
-   * @param classLoader the class loader where the builder implementation will be looked up.
-   * @return a new {@link Builder} based on the template {@code message} provided.
-   */
-  static Builder builder(Message message, ClassLoader classLoader) {
-    // TODO: remove after test if successful
-    return AbstractMuleMessageBuilderFactory.getDefaultFactory().create(message);
-  }
-
-  /**
    * Gets a {@link TypedValue} with the payload of this message.
    *
    * @param <T> the type of the payload.
@@ -102,20 +75,6 @@ public interface Message extends Serializable {
    */
   static Message of(Object payload) {
     return builder().value(payload).build();
-  }
-
-  /**
-   * Create a new {@link Message instance} with the given payload.
-   * <p>
-   * <b>NOTE</b>: this method is for internal use only.
-   *
-   * @param classLoader the class loader where the builder implementation will be looked up.
-   *
-   * @param payload     the message payload
-   * @return new message instance
-   */
-  static Message of(Object payload, ClassLoader classLoader) {
-    return builder(classLoader).value(payload).build();
   }
 
   /**

--- a/src/main/java/org/mule/runtime/api/metadata/AbstractDataTypeBuilderFactory.java
+++ b/src/main/java/org/mule/runtime/api/metadata/AbstractDataTypeBuilderFactory.java
@@ -15,6 +15,9 @@ import static java.util.ServiceLoader.load;
 import org.mule.api.annotation.NoExtend;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,62 +32,59 @@ public abstract class AbstractDataTypeBuilderFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDataTypeBuilderFactory.class);
 
   private static AbstractDataTypeBuilderFactory loadFactory(ClassLoader classLoader) {
-    if (DEFAULT_FACTORY == null) {
-      try {
-        final AbstractDataTypeBuilderFactory factory =
-            load(AbstractDataTypeBuilderFactory.class, classLoader).iterator().next();
-        LOGGER.info(format("Loaded AbstractDataTypeBuilderFactory implementation '%s' from classloader '%s'",
-                           factory.getClass().getName(), factory.getClass().getClassLoader().toString()));
+    try {
+      final AbstractDataTypeBuilderFactory factory =
+          load(AbstractDataTypeBuilderFactory.class, classLoader).iterator().next();
+      LOGGER.info(format("Loaded AbstractDataTypeBuilderFactory implementation '%s' from classloader '%s'",
+                         factory.getClass().getName(), factory.getClass().getClassLoader().toString()));
 
-        DEFAULT_FACTORY = factory;
-      } catch (Throwable t) {
-        LOGGER.error("Error loading AbstractDataTypeBuilderFactory implementation.", t);
-        throw t;
-      }
+      return factory;
+    } catch (Throwable t) {
+      LOGGER.error("Error loading AbstractDataTypeBuilderFactory implementation.", t);
+      throw t;
     }
-
-    return DEFAULT_FACTORY;
   }
 
-  private static AbstractDataTypeBuilderFactory DEFAULT_FACTORY;
+  private static final Map<ClassLoader, AbstractDataTypeBuilderFactory> factoriesMap = new HashMap<>();
 
   /**
    * The implementation of this abstract class is provided by the Mule Runtime.
    * <p>
    * If more than one implementation is found, the classLoading order of those implementations will determine which one is used.
    * Information about this will be logged to aid in the troubleshooting of those cases.
-   * 
+   *
    * @return the implementation of this builder factory provided by the Mule Runtime.
    */
-  static final AbstractDataTypeBuilderFactory getDefaultFactory() {
+  static AbstractDataTypeBuilderFactory getDefaultFactory() {
+    ClassLoader contextClassLoader = currentThread().getContextClassLoader();
     try {
-      return getDefaultFactory(currentThread().getContextClassLoader());
+      return getDefaultFactory(contextClassLoader);
     } catch (Throwable t) {
       ClassLoader classLoader;
       try {
-        classLoader = currentThread().getContextClassLoader().loadClass("org.mule.runtime.core.api.MuleContext").getClassLoader();
+        classLoader = contextClassLoader.loadClass("org.mule.runtime.core.api.MuleContext").getClassLoader();
       } catch (ClassNotFoundException e) {
         throw new MuleRuntimeException(createStaticMessage("Failed obtaining class loader to load AbstractDataTypeBuilderFactory implementation"),
                                        e);
       }
 
-      return getDefaultFactory(classLoader);
+      AbstractDataTypeBuilderFactory defaultFactory = null;
+      try {
+        defaultFactory = getDefaultFactory(classLoader);
+      } finally {
+        // Next time this thread's context class loader is used to retrieve the factory, we return it instead of computing it
+        // again
+        if (defaultFactory != null) {
+          factoriesMap.put(contextClassLoader, defaultFactory);
+        }
+      }
+
+      return defaultFactory;
     }
   }
 
-  /**
-   * The implementation of this abstract class is provided by the Mule Runtime.
-   * <p>
-   * If more than one implementation is found, the classLoading order of those implementations will determine which one is used.
-   * Information about this will be logged to aid in the troubleshooting of those cases.
-   * <p>
-   * <b>NOTE</b>: this method is for internal use only.
-   *
-   * @param classLoader the class loader where the implementation will be looked up.
-   * @return the implementation of this builder factory provided by the Mule Runtime.
-   */
-  static AbstractDataTypeBuilderFactory getDefaultFactory(ClassLoader classLoader) {
-    return loadFactory(classLoader);
+  private static AbstractDataTypeBuilderFactory getDefaultFactory(ClassLoader classLoader) {
+    return factoriesMap.computeIfAbsent(classLoader, AbstractDataTypeBuilderFactory::loadFactory);
   }
 
   /**

--- a/src/main/java/org/mule/runtime/api/metadata/AbstractDataTypeBuilderFactory.java
+++ b/src/main/java/org/mule/runtime/api/metadata/AbstractDataTypeBuilderFactory.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.api.metadata;
 
 import static java.lang.String.format;
+import static java.lang.Thread.currentThread;
 import static java.util.ServiceLoader.load;
 
 import org.mule.api.annotation.NoExtend;
@@ -27,7 +28,7 @@ public abstract class AbstractDataTypeBuilderFactory {
   static {
     try {
       final AbstractDataTypeBuilderFactory factory = load(AbstractDataTypeBuilderFactory.class,
-                                                          AbstractDataTypeBuilderFactory.class.getClassLoader())
+                                                          currentThread().getContextClassLoader())
                                                               .iterator().next();
       LOGGER.debug(format("Loaded AbstractDataTypeBuilderFactory implementation '%s' from classloader '%s'",
                           factory.getClass().getName(), factory.getClass().getClassLoader().toString()));

--- a/src/main/java/org/mule/runtime/api/metadata/AbstractDataTypeBuilderFactory.java
+++ b/src/main/java/org/mule/runtime/api/metadata/AbstractDataTypeBuilderFactory.java
@@ -33,12 +33,12 @@ public abstract class AbstractDataTypeBuilderFactory {
       try {
         final AbstractDataTypeBuilderFactory factory =
             load(AbstractDataTypeBuilderFactory.class, classLoader).iterator().next();
-        LOGGER.info(format("Loaded MuleMessageBuilderFactory implementation '%s' from classloader '%s'",
+        LOGGER.info(format("Loaded AbstractDataTypeBuilderFactory implementation '%s' from classloader '%s'",
                            factory.getClass().getName(), factory.getClass().getClassLoader().toString()));
 
         DEFAULT_FACTORY = factory;
       } catch (Throwable t) {
-        LOGGER.error("Error loading MuleMessageBuilderFactory implementation.", t);
+        LOGGER.error("Error loading AbstractDataTypeBuilderFactory implementation.", t);
         throw t;
       }
     }
@@ -64,8 +64,7 @@ public abstract class AbstractDataTypeBuilderFactory {
       try {
         classLoader = currentThread().getContextClassLoader().loadClass("org.mule.runtime.core.api.MuleContext").getClassLoader();
       } catch (ClassNotFoundException e) {
-        throw new MuleRuntimeException(createStaticMessage(format("Failed obtaining class loader to load %s",
-                                                                  AbstractDataTypeBuilderFactory.class.getName())),
+        throw new MuleRuntimeException(createStaticMessage("Failed obtaining class loader to load AbstractDataTypeBuilderFactory implementation"),
                                        e);
       }
 


### PR DESCRIPTION
The current approach of searching the services implementations from the class loader of the service contract class worked well because `mule-api` (services contracts) and `mule-core` (services implementations) were always within the same class loader. Now, for the [Multi Mule support](https://docs.google.com/document/d/1Js0hauEpnAEFInOJXrvROkjlALCe5LaHJ2YcHu6DqRE/edit#heading=h.pvww9i63jif) implementation in the Mule Framework that is no longer true, since `mule-core` will be in a class loader which is a child of `mule-api`'s class loader, making this approach non-viable.