### PR TITLE
W-15643200: output json --- error fails with NullPointerException aft…

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -132,6 +132,7 @@ module org.mule.runtime.api {
 
   // for DataWeave
   exports org.mule.runtime.privileged.event;
+  exports org.mule.runtime.privileged.exception;
 
   // For runtime-extension-model and extensions-support
   exports org.mule.runtime.privileged.metadata;
@@ -153,6 +154,12 @@ module org.mule.runtime.api {
       org.mule.runtime.extensions.support;
   opens org.mule.runtime.api.exception to
       org.mule.runtime.extensions.support,
+      // Introspection by kryo used by mule serializer
+      kryo.shaded;
+  opens org.mule.runtime.privileged.exception to
+      // Introspection by kryo used by mule serializer
+      kryo.shaded;
+  opens org.mule.runtime.api.lifecycle to
       // Introspection by kryo used by mule serializer
       kryo.shaded;
   opens org.mule.runtime.api.message to

--- a/src/main/java/org/mule/runtime/api/exception/ExceptionHelper.java
+++ b/src/main/java/org/mule/runtime/api/exception/ExceptionHelper.java
@@ -17,7 +17,7 @@ import static org.mule.runtime.api.exception.MuleException.MULE_VERBOSE_EXCEPTIO
 
 import org.mule.runtime.api.legacy.exception.ExceptionReader;
 import org.mule.runtime.api.util.collection.SmallMap;
-import org.mule.runtime.internal.exception.SuppressedMuleException;
+import org.mule.runtime.privileged.exception.SuppressedMuleException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;

--- a/src/main/java/org/mule/runtime/internal/exception/SuppressedMuleException.java
+++ b/src/main/java/org/mule/runtime/internal/exception/SuppressedMuleException.java
@@ -6,114 +6,23 @@
  */
 package org.mule.runtime.internal.exception;
 
-import static java.util.Objects.requireNonNull;
-
 import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.api.message.Error;
 
 /**
- * Wraps a provided exception, suppressing a {@link MuleException} that is part of it's cause tree, meaning that the Mule Runtime
- * will not take it into account for the error handling. The suppressed cause and all its nested {@link Exception#getCause()} will
- * not be taken into account during the {@link org.mule.runtime.api.message.Error} resolution. <br/>
- * <br/>
- * Example without suppression: <br/>
- * 
- * <pre>
- * throw new {@link org.mule.runtime.api.exception.TypedException}(new {@link org.mule.runtime.api.connection.ConnectionException}(), {@link org.mule.runtime.api.message.ErrorType customErrorType})
- * </pre>
- * 
- * will resolve to an {@link Error} with {@link Error#getErrorType()} returning ConnectionException's error type (discarding the
- * top level customErrorType). <br/>
- * <br/>
- * Same example with suppression: <br/>
- * 
- * <pre>
- * throw new {@link org.mule.runtime.api.exception.TypedException}(new {@link SuppressedMuleException}(new {@link org.mule.runtime.api.connection.ConnectionException}()), {@link org.mule.runtime.api.message.ErrorType customErrorType})
- * </pre>
- * 
- * will resolve to an {@link Error} with {@link Error#getErrorType()} returning customErrorType (discarding the underlying
- * ConnectionException's error type}).
- * 
+ * @see org.mule.runtime.privileged.exception.SuppressedMuleException
  * @since 1.2.3, 1.3
  */
-public class SuppressedMuleException extends MuleException {
+public class SuppressedMuleException extends org.mule.runtime.privileged.exception.SuppressedMuleException {
 
   private static final long serialVersionUID = -2020531237382360468L;
 
-  private final MuleException suppressedException;
-
   /**
    * Constructs a new {@link SuppressedMuleException}
-   * 
+   *
    * @param throwable       Exception that will be wrapped.
    * @param causeToSuppress The cause that wants to be suppressed. Cannot be null.
    */
-  private SuppressedMuleException(Throwable throwable, MuleException causeToSuppress) {
-    super(requireNonNull(throwable, "Exception cannot be null"));
-    this.suppressedException = requireNonNull(causeToSuppress, "Cannot suppress a null cause");
-    addSuppressionToMuleExceptionInfo(causeToSuppress);
+  protected SuppressedMuleException(Throwable throwable, MuleException causeToSuppress) {
+    super(throwable, causeToSuppress);
   }
-
-  /**
-   * Completes the {@link org.mule.runtime.api.exception.MuleExceptionInfo} of a {@link SuppressedMuleException} by adding the
-   * {@link MuleException} that is being suppressed and traversing its causes to include any other suppression found and also the
-   * additional information from all the {@link MuleException}s.
-   * 
-   * @param causeToSuppress Exception that is being suppressed.
-   */
-  private void addSuppressionToMuleExceptionInfo(MuleException causeToSuppress) {
-    this.getExceptionInfo().addSuppressedCause(causeToSuppress);
-    this.addAllInfo(causeToSuppress.getAdditionalInfo());
-    Throwable nestedCause = causeToSuppress;
-    while (nestedCause.getCause() != null && nestedCause.getCause() != nestedCause) {
-      nestedCause = nestedCause.getCause();
-      if (nestedCause instanceof MuleException) {
-        this.addAllInfo(((MuleException) nestedCause).getAdditionalInfo());
-        if (nestedCause instanceof SuppressedMuleException) {
-          this.getExceptionInfo().addSuppressedCause(((SuppressedMuleException) nestedCause).getSuppressedException());
-        }
-      }
-    }
-  }
-
-  /**
-   * Unwraps a {@link SuppressedMuleException}.
-   * 
-   * @return First cause that is not an instance of {@link SuppressedMuleException}.
-   */
-  public Throwable unwrap() {
-    // There cannot be consecutive suppressions, so returning the cause is enough
-    return getCause();
-  }
-
-  /**
-   * @return {@link MuleException} that has been suppressed by this {@link SuppressedMuleException}.
-   */
-  public MuleException getSuppressedException() {
-    return suppressedException;
-  }
-
-  /**
-   * Wraps the provided exception, suppressing the exception itself or the first cause that is an instance of the provided class.
-   * The search will stop if a {@link SuppressedMuleException} is found, making no suppression.
-   * 
-   * @param exception       Exception that will be wrapped, suppressing the exception itself or one of it's causes.
-   * @param causeToSuppress Class of the {@link MuleException} that has to be suppressed.
-   * @return {@link SuppressedMuleException} or provided exception if no cause to suppress is found.
-   */
-  public static Throwable suppressIfPresent(Throwable exception, Class<? extends MuleException> causeToSuppress) {
-    Throwable cause = exception;
-    while (cause != null && !(cause instanceof SuppressedMuleException)) {
-      if (causeToSuppress.isInstance(cause)) {
-        return new SuppressedMuleException(exception, (MuleException) cause);
-      }
-      if (cause.getCause() != cause) {
-        cause = cause.getCause();
-      } else {
-        break;
-      }
-    }
-    return exception;
-  }
-
 }

--- a/src/main/java/org/mule/runtime/privileged/exception/SuppressedMuleException.java
+++ b/src/main/java/org/mule/runtime/privileged/exception/SuppressedMuleException.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.privileged.exception;
+
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.message.Error;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Wraps a provided exception, suppressing a {@link MuleException} that is part of it's cause tree, meaning that the Mule Runtime
+ * will not take it into account for the error handling. The suppressed cause and all its nested {@link Exception#getCause()} will
+ * not be taken into account during the {@link Error} resolution. <br/>
+ * <br/>
+ * Example without suppression: <br/>
+ * 
+ * <pre>
+ * throw new {@link org.mule.runtime.api.exception.TypedException}(new {@link org.mule.runtime.api.connection.ConnectionException}(), {@link org.mule.runtime.api.message.ErrorType customErrorType})
+ * </pre>
+ * 
+ * will resolve to an {@link Error} with {@link Error#getErrorType()} returning ConnectionException's error type (discarding the
+ * top level customErrorType). <br/>
+ * <br/>
+ * Same example with suppression: <br/>
+ * 
+ * <pre>
+ * throw new {@link org.mule.runtime.api.exception.TypedException}(new {@link SuppressedMuleException}(new {@link org.mule.runtime.api.connection.ConnectionException}()), {@link org.mule.runtime.api.message.ErrorType customErrorType})
+ * </pre>
+ * 
+ * will resolve to an {@link Error} with {@link Error#getErrorType()} returning customErrorType (discarding the underlying
+ * ConnectionException's error type}).
+ * 
+ * @since 1.2.3, 1.3
+ */
+public class SuppressedMuleException extends MuleException {
+
+  private static final long serialVersionUID = -2810315886149183162L;
+
+  private final MuleException suppressedException;
+
+  /**
+   * Constructs a new {@link SuppressedMuleException}
+   * 
+   * @param throwable       Exception that will be wrapped.
+   * @param causeToSuppress The cause that wants to be suppressed. Cannot be null.
+   */
+  protected SuppressedMuleException(Throwable throwable, MuleException causeToSuppress) {
+    super(requireNonNull(throwable, "Exception cannot be null"));
+    this.suppressedException = requireNonNull(causeToSuppress, "Cannot suppress a null cause");
+    addSuppressionToMuleExceptionInfo(causeToSuppress);
+  }
+
+  /**
+   * Completes the {@link org.mule.runtime.api.exception.MuleExceptionInfo} of a {@link SuppressedMuleException} by adding the
+   * {@link MuleException} that is being suppressed and traversing its causes to include any other suppression found and also the
+   * additional information from all the {@link MuleException}s.
+   * 
+   * @param causeToSuppress Exception that is being suppressed.
+   */
+  private void addSuppressionToMuleExceptionInfo(MuleException causeToSuppress) {
+    this.getExceptionInfo().addSuppressedCause(causeToSuppress);
+    this.addAllInfo(causeToSuppress.getAdditionalInfo());
+    Throwable nestedCause = causeToSuppress;
+    while (nestedCause.getCause() != null && nestedCause.getCause() != nestedCause) {
+      nestedCause = nestedCause.getCause();
+      if (nestedCause instanceof MuleException) {
+        this.addAllInfo(((MuleException) nestedCause).getAdditionalInfo());
+        if (nestedCause instanceof SuppressedMuleException) {
+          this.getExceptionInfo().addSuppressedCause(((SuppressedMuleException) nestedCause).getSuppressedException());
+        }
+      }
+    }
+  }
+
+  /**
+   * Unwraps a {@link SuppressedMuleException}.
+   * 
+   * @return First cause that is not an instance of {@link SuppressedMuleException}.
+   */
+  public Throwable unwrap() {
+    // There cannot be consecutive suppressions, so returning the cause is enough
+    return getCause();
+  }
+
+  /**
+   * @return {@link MuleException} that has been suppressed by this {@link SuppressedMuleException}.
+   */
+  public MuleException getSuppressedException() {
+    return suppressedException;
+  }
+
+  /**
+   * Wraps the provided exception, suppressing the exception itself or the first cause that is an instance of the provided class.
+   * The search will stop if a {@link SuppressedMuleException} is found, making no suppression.
+   * 
+   * @param exception       Exception that will be wrapped, suppressing the exception itself or one of it's causes.
+   * @param causeToSuppress Class of the {@link MuleException} that has to be suppressed.
+   * @return {@link SuppressedMuleException} or provided exception if no cause to suppress is found.
+   */
+  public static Throwable suppressIfPresent(Throwable exception, Class<? extends MuleException> causeToSuppress) {
+    Throwable cause = exception;
+    while (cause != null && !(cause instanceof SuppressedMuleException)) {
+      if (causeToSuppress.isInstance(cause)) {
+        return new SuppressedMuleException(exception, (MuleException) cause);
+      }
+      if (cause.getCause() != cause) {
+        cause = cause.getCause();
+      } else {
+        break;
+      }
+    }
+    return exception;
+  }
+
+  @Override
+  public String getVerboseMessage() {
+    // SuppressedException is meant to marks as suppressed another exception that is part of the cause tree.
+    return "Suppressed: " + super.getSummaryMessage();
+  }
+
+  @Override
+  public String getSummaryMessage() {
+    // SuppressedException is meant to marks as suppressed another exception that is part of the cause tree.
+    return "Suppressed: " + super.getSummaryMessage();
+  }
+}

--- a/src/test/java/org/mule/runtime/api/test/internal/exception/SuppressedMuleExceptionTestCase.java
+++ b/src/test/java/org/mule/runtime/api/test/internal/exception/SuppressedMuleExceptionTestCase.java
@@ -6,27 +6,67 @@
  */
 package org.mule.runtime.api.test.internal.exception;
 
-import io.qameta.allure.Issue;
-import org.junit.Test;
-import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.internal.exception.SuppressedMuleException;
-
-import java.util.List;
-import java.util.Map;
-
+import static java.lang.Boolean.parseBoolean;
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.core.Is.is;
+import static org.mule.runtime.api.exception.MuleException.MULE_VERBOSE_EXCEPTIONS;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.i18n.I18nMessage;
+import org.mule.runtime.api.i18n.I18nMessageFactory;
+import org.mule.runtime.privileged.exception.SuppressedMuleException;
+
+import java.util.List;
+import java.util.Map;
+
+import io.qameta.allure.Issue;
+import org.junit.Test;
+
+@RunWith(Parameterized.class)
 public class SuppressedMuleExceptionTestCase {
+
+  private final boolean isVerboseExceptions;
+  private boolean wasVerboseExceptions;
+
+  @Parameterized.Parameters(name = "Verbose exceptions: {0}")
+  public static List<Object[]> parameters() {
+    return asList(
+                  new Object[] {true},
+                  new Object[] {false});
+  }
+
+  public SuppressedMuleExceptionTestCase(boolean isVerboseExceptions) {
+    this.isVerboseExceptions = isVerboseExceptions;
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    this.wasVerboseExceptions = parseBoolean(System.clearProperty(MULE_VERBOSE_EXCEPTIONS));
+    System.setProperty(MULE_VERBOSE_EXCEPTIONS, Boolean.toString(isVerboseExceptions));
+    MuleException.refreshVerboseExceptions();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    System.setProperty(MULE_VERBOSE_EXCEPTIONS, Boolean.toString(wasVerboseExceptions));
+  }
 
   @Test
   @Issue("MULE-18041")
   public void whenClassToSuppressIsNotFoundThenNoSuppressionIsAdded() {
-    Throwable result = SuppressedMuleException.suppressIfPresent(new SimpleException(), ExceptionWithAdditionalInfo.class);
+    Throwable result =
+        SuppressedMuleException.suppressIfPresent(new SimpleException(I18nMessageFactory.createStaticMessage("Test")),
+                                                  ExceptionWithAdditionalInfo.class);
     assertThat(result, is(instanceOf(SimpleException.class)));
   }
 
@@ -57,7 +97,8 @@ public class SuppressedMuleExceptionTestCase {
   @Test
   @Issue("MULE-18041")
   public void whenSuppressionIsAddedThenPreviousSuppressionsAreAdded() {
-    Throwable suppressedTestException = SuppressedMuleException.suppressIfPresent(new SimpleException(), SimpleException.class);
+    Throwable suppressedTestException = SuppressedMuleException
+        .suppressIfPresent(new SimpleException(I18nMessageFactory.createStaticMessage("Test")), SimpleException.class);
     Throwable suppressedAnotherTestException =
         SuppressedMuleException.suppressIfPresent(new ExceptionWithAdditionalInfo(suppressedTestException),
                                                   ExceptionWithAdditionalInfo.class);
@@ -105,21 +146,37 @@ public class SuppressedMuleExceptionTestCase {
   public void suppressionMustBeUnwrapped() {
     SimpleException unwrappedException = new SimpleException();
     SuppressedMuleException result =
-        (SuppressedMuleException) SuppressedMuleException.suppressIfPresent(new SimpleException(),
+        (SuppressedMuleException) SuppressedMuleException.suppressIfPresent(unwrappedException,
                                                                             SimpleException.class);
     assertThat(result.unwrap(), is(unwrappedException));
+  }
+
+  @Test
+  @Issue("W-15643200")
+  public void suppressionMustHaveItsOwnDetailedMessage() {
+    SimpleException unwrappedException = new SimpleException(I18nMessageFactory.createStaticMessage("Test"));
+    SuppressedMuleException result =
+        (SuppressedMuleException) SuppressedMuleException
+            .suppressIfPresent(new SimpleException(I18nMessageFactory.createStaticMessage("Test")),
+                               SimpleException.class);
+    assertThat(result.getDetailedMessage(), equalTo("Suppressed: " + unwrappedException.getMessage()));
   }
 
   private static class SimpleException extends MuleException {
 
     private static final long serialVersionUID = 21078091124109763L;
 
-    public SimpleException() {}
+    public SimpleException(I18nMessage test) {
+      super(test);
+    }
 
     public SimpleException(Throwable cause) {
       super(cause);
     }
 
+    public SimpleException() {
+      super();
+    }
   }
 
   private static class ExceptionWithAdditionalInfo extends MuleException {


### PR DESCRIPTION
…er "MULE:RETRIES_EXHAUSTED" (#1371)

(cherry picked from commit 9f55741f291e57572177232fe73b50ea2dc4f1ab)