### PR TITLE
W-16237424 Add trim() to name and namespace of ComponentIdentifier

### DIFF
--- a/src/main/java/org/mule/runtime/api/component/DefaultComponentIdentifier.java
+++ b/src/main/java/org/mule/runtime/api/component/DefaultComponentIdentifier.java
@@ -70,6 +70,7 @@ public class DefaultComponentIdentifier implements ComponentIdentifier, Serializ
      */
     @Override
     public Builder namespace(String namespace) {
+      namespace = namespace.trim();
       componentIdentifier.namespace = namespace;
       componentIdentifier.namespaceLowerCase = namespace.toLowerCase();
       return this;
@@ -87,7 +88,7 @@ public class DefaultComponentIdentifier implements ComponentIdentifier, Serializ
      */
     @Override
     public Builder name(String identifier) {
-      componentIdentifier.name = identifier;
+      componentIdentifier.name = identifier.trim();
       return this;
     }
 


### PR DESCRIPTION
Problem: The Mule app fails to deploy due to an error in the raise-error component when the error type is provided with an extra space at the end (e.g., type="ERROR:404 BAD DATA "). The regression was caught in this [bug](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001wkZveYAE/view).

What was the error?
Customers can specify the error type string in the XML. In this case, the user provided the error type as “ERROR:404 BAD DATA ” in the component. When the Mule application parsed the XML file and tried to build the AST tree, it encountered an error as it was trying to get the error type for “ERROR:404 BAD DATA” in the errorTypeRepository. This caused the application to fail to deploy for Mule version 4.5+.
On further investigation we also reproduced the following error
When running the application with -M-Dmule.deployment.forceParseConfigXmls=true, we do not use a ast serialization and instead force parse the config xml. We use the DefaultErrorTypeRepository to perform lookup operations for different ErrorTypes in the mule artifact. In this too we were getting the same error.