### PR TITLE
W-16237424 Add trim to() DefaultComponentIdentifier builder

### DIFF
--- a/src/main/java/org/mule/runtime/api/component/DefaultComponentIdentifier.java
+++ b/src/main/java/org/mule/runtime/api/component/DefaultComponentIdentifier.java
@@ -70,6 +70,7 @@ public class DefaultComponentIdentifier implements ComponentIdentifier, Serializ
      */
     @Override
     public Builder namespace(String namespace) {
+      namespace = namespace.trim();
       componentIdentifier.namespace = namespace;
       componentIdentifier.namespaceLowerCase = namespace.toLowerCase();
       return this;
@@ -87,7 +88,7 @@ public class DefaultComponentIdentifier implements ComponentIdentifier, Serializ
      */
     @Override
     public Builder name(String identifier) {
-      componentIdentifier.name = identifier;
+      componentIdentifier.name = identifier.trim();
       return this;
     }
 

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -34,6 +34,7 @@ module org.mule.runtime.api.test {
   requires jsonassert;
 
   exports org.mule.runtime.api.test;
+  exports org.mule.runtime.api.test.component;
   exports org.mule.runtime.api.test.component.execution;
   exports org.mule.runtime.api.test.component.location;
   exports org.mule.runtime.api.test.el;

--- a/src/test/java/org/mule/runtime/api/test/component/DefaultComponentIdentifierTestCase.java
+++ b/src/test/java/org/mule/runtime/api/test/component/DefaultComponentIdentifierTestCase.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.api.test.component;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.mule.runtime.api.component.ComponentIdentifier;
+import org.mule.runtime.api.component.DefaultComponentIdentifier;
+
+import io.qameta.allure.Issue;
+import org.junit.Test;
+
+public class DefaultComponentIdentifierTestCase {
+
+  @Test
+  @Issue("W-16237424")
+  public void testBuilderWithValidParametersWithLeadingWhiteSpace() {
+    String namespace = " namespace";
+    String name = " name";
+
+    ComponentIdentifier componentIdentifier = DefaultComponentIdentifier.builder().namespace(namespace).name(name).build();
+
+    assertThat(componentIdentifier.getName(), is("name"));
+    assertThat(componentIdentifier.getNamespace(), is("namespace"));
+  }
+
+  @Test
+  @Issue("W-16237424")
+  public void testBuilderWithValidParametersWithTrailingWhiteSpace() {
+    String namespace = "namespace   ";
+    String name = "name    ";
+
+    ComponentIdentifier componentIdentifier = DefaultComponentIdentifier.builder().namespace(namespace).name(name).build();
+
+    assertThat(componentIdentifier.getName(), is("name"));
+    assertThat(componentIdentifier.getNamespace(), is("namespace"));
+  }
+}


### PR DESCRIPTION
**Problem**: The Mule app fails to deploy due to an error in the raise-error component when the error type is provided with an extra space at the end (e.g., type="ERROR:404 BAD DATA "). The regression was caught in this [bug](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001wkZveYAE/view).

**What was the error?**
Customers can specify the error type string in the XML. In this case, the user provided the error type as “ERROR:404 BAD DATA ” in the component. When the Mule application parsed the XML file and tried to build the AST tree, it encountered an error as it was trying to get the error type for “ERROR:404 BAD DATA” in the errorTypeRepository. This caused the application to fail to deploy for Mule version 4.5+.
On further investigation we also reproduced the following error
When running the application with -M-Dmule.deployment.forceParseConfigXmls=true, we do not use a ast serialization and instead force parse the config xml. We use the DefaultErrorTypeRepository to perform lookup operations for different ErrorTypes in the mule artifact. In this too we were getting the error.