### PR TITLE
W-17774685: Fix serialization of Result objects with Java 17

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -225,7 +225,8 @@ module org.mule.runtime.api {
   opens org.mule.runtime.api.metadata to
       org.mule.runtime.extensions.support,
       com.google.gson,
-      org.mule.runtime.api.test;
+      org.mule.runtime.api.test,
+      kryo.shaded;
   opens org.mule.runtime.api.metadata.resolving to
       com.google.gson;
   opens org.mule.runtime.api.value to


### PR DESCRIPTION
This one is needed only in 4.6 because in newer branches we already have this one: https://github.com/mulesoft/mule-api/commit/d7e6c15e4a77a63e2a703f934b60e7689917f08b